### PR TITLE
주간캘린더 과거/미래 근무 날짜 카드 색상 구분

### DIFF
--- a/src/components/common/WeeklyDateBar.tsx
+++ b/src/components/common/WeeklyDateBar.tsx
@@ -54,35 +54,36 @@ const WeeklyDateBar: React.FC<WeeklyDateBarProps> = ({
 			{/* 요일/날짜 카드 행 */}
 			<View style={styles.daysRow}>
 				{weekDays.map((day) => {
-					const isToday = getIsSelected(day);
-					const hasScheduled = !isToday && day.workStatus === "SCHEDULED";
-					const hasCompleted = !isToday && day.workStatus === "COMPLETED";
+					const isSelected = getIsSelected(day);
+					const hasWork = !!day.workStatus && day.workStatus !== "DELETED";
+					const isPastWithWork = !isSelected && day.isPast && hasWork;
+					const isFutureWithWork = !isSelected && !day.isPast && hasWork;
 					return (
 						<TouchableOpacity
 							key={day.date}
 							style={[
 								styles.dayCard,
-								isToday && styles.dayCardToday,
-								hasScheduled && styles.dayCardScheduled,
-								hasCompleted && styles.dayCardCompleted,
+								isSelected && styles.dayCardToday,
+								isFutureWithWork && styles.dayCardScheduled,
+								isPastWithWork && styles.dayCardCompleted,
 							]}
 							onPress={() => onPressDay?.(day)}
 							activeOpacity={0.7}
 						>
 							<Text
-								weight={isToday ? "Bold" : "Medium"}
+								weight={isSelected ? "Bold" : "Medium"}
 								style={[
 									styles.dayLabel,
-									isToday && styles.textToday,
+									isSelected && styles.textToday,
 								]}
 							>
 								{day.dayLabel}
 							</Text>
 							<Text
-								weight={isToday ? "Bold" : "SemiBold"}
+								weight={isSelected ? "Bold" : "SemiBold"}
 								style={[
 									styles.dateText,
-									isToday && styles.textToday,
+									isSelected && styles.textToday,
 								]}
 							>
 								{day.date}
@@ -133,7 +134,7 @@ const styles = StyleSheet.create({
 		backgroundColor: colors.mint,
 	},
 	dayCardCompleted: {
-		backgroundColor: colors.grey,
+		backgroundColor: colors.disabled,
 	},
 	dayLabel: {
 		fontSize: 12,

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -30,8 +30,8 @@ export const colors = {
 	green: "#28C28D",
 
 	// 기타
- 	blue: "#038BFA",
-	grey: "#EEEEEE",
+  blue: "#038BFA",
+	grey: "#A0A0A0",
 	white: "#FFFFFF",
 	black: "#000000",
 	disabled: "#EEEEEE",

--- a/src/screens/worker/WorkerWeeklyCalendarScreen.tsx
+++ b/src/screens/worker/WorkerWeeklyCalendarScreen.tsx
@@ -18,6 +18,7 @@ import useCorrectionRequest from "../../hooks/worker/useCorrectionRequest";
 import useWorkRecords from "../../hooks/worker/useWorkRecords";
 import { useLogoutHandler } from "../../hooks/common/useLogoutHandler";
 import { colors } from "../../constants/colors";
+import type { WeekDay } from "../../types/worker.types";
 import {
 	getWeekTitle,
 	getWeekDays,
@@ -41,11 +42,24 @@ const WorkerWeeklyCalendarScreen: React.FC<Props> = ({ navigation }) => {
 	
 	const today = new Date();
 	const weekTitle = getWeekTitle(today);
-	const weekDays = getWeekDays(today);
+	const baseWeekDays = getWeekDays(today);
 	const weekLabel = getWeekLabel(today);
 	const { startDate, endDate } = useMemo(() => getWeekRange(today), []);
 
 	const { works, isLoading } = useWorkRecords(startDate, endDate);
+
+	// 근무 데이터를 날짜 카드에 매핑
+	const weekDays = useMemo(() => {
+		const workDateMap = new Map<number, string>();
+		works.forEach((w) => {
+			const date = new Date(`${w.workDate}T00:00:00`).getDate();
+			workDateMap.set(date, w.status);
+		});
+		return baseWeekDays.map((day) => ({
+			...day,
+			workStatus: workDateMap.get(day.date) as WeekDay["workStatus"],
+		}));
+	}, [baseWeekDays, works]);
 
 	const {
 		correctionModalVisible,

--- a/src/types/worker.types.ts
+++ b/src/types/worker.types.ts
@@ -35,6 +35,7 @@ export interface WeekDay {
 	dayLabel: string; // "Mon", "Tue", ...
 	date: number; // 21, 22, ...
 	isToday: boolean;
+	isPast: boolean;
 	workStatus?: WorkStatus; // 해당 날짜의 근무 상태 (API 응답 기반)
 }
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -51,13 +51,18 @@ export const getWeekDays = (baseDate: Date): WeekDay[] => {
 
 	const todayStr = baseDate.toDateString();
 
+	const todayStart = new Date(baseDate);
+	todayStart.setHours(0, 0, 0, 0);
+
 	return DAY_LABELS.map((label, i) => {
 		const d = new Date(monday);
 		d.setDate(monday.getDate() + i);
+		d.setHours(0, 0, 0, 0);
 		return {
 			dayLabel: label,
 			date: d.getDate(),
 			isToday: d.toDateString() === todayStr,
+			isPast: d.getTime() < todayStart.getTime(),
 		};
 	});
 };


### PR DESCRIPTION
## 📌 Issue number and Link
closed #15

## ✏️ Summary
주간캘린더에서 과거 근무일과 미래 근무일의 날짜 카드를 색상으로 구분하여 시각적 피드백을 제공합니다.

## 📝 Changes
- `WeekDay` 인터페이스에 `isPast` 필드 추가 및 `getWeekDays()`에서 자정 기준 자동 계산
- `WorkerWeeklyCalendarScreen`에서 근무 데이터(`works`)를 날짜 카드의 `workStatus`에 매핑하는 로직 추가
- `WeeklyDateBar` 날짜 카드 스타일 분기:
  - 과거 근무일 → `disabled`(#EEEEEE) 배경
  - 미래 근무일 → `mint`(#E0F2F1) 배경
  - 오늘(선택된 날짜) → `primary`(파란색) 유지
  - 근무 없는 날짜 → 기존 흰색 유지
- `colors.ts` 기존 변경사항 포함

## 🔎 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot