### PR TITLE
[Fix] BottomSheetModal 키보드 버그 수정 (#32)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ PayCheck 웹 프로젝트(payCheck-frontend)를 React Native(Expo)로 모바일 
 - **목표**: payCheck-frontend(React 웹앱)을 모바일 앱으로 포팅
 - **웹 원본**: `../payCheck-frontend`
 - **프레임워크**: React Native + Expo
-- **상태**: 근로자 기능 구현 완료, 고용주 마이페이지 구현 중
+- **상태**: 근로자/고용주 기능 구현 완료, 공지 게시판 구현 완료
 
 ## 기술 스택
 
@@ -50,12 +50,16 @@ src/
 │   ├── user/         # 사용자 API (프로필 조회/수정, 계좌 정보 수정)
 │   ├── worker/       # 근로자 API (계약, 근무기록, 정정요청, 급여, 송금)
 │   ├── employer/     # 고용주 API (근무지 CRUD, 계약 CRUD, 정정요청 승인/거절)
+│   ├── notice/       # 공지 API (공지 CRUD)
 │   └── kakao/        # 카카오 API (주소 검색)
 ├── assets/           # 폰트, 이미지
 ├── components/
-│   ├── common/       # Text, PrimaryButton, BottomSheetModal, WheelPicker, MonthlyCalendar, Pagination 등
+│   ├── common/       # Text, PrimaryButton, BottomSheetModal, WheelPicker, MonthlyCalendar, Pagination, NoticeBoard 등
+│   │   └── notice/          # 공지 컴포넌트 (NoticeCreateModal, NoticeDetailSheet, NoticeEditSheet, NoticeCategorySelector)
 │   ├── employer/
-│   │   ├── worker-manage/   # 직원관리 (WorkerCard, AddWorkerModal 등)
+│   │   ├── home/            # 고용주 홈 (근무 추가/수정 모달)
+│   │   ├── worker-manage/   # 직원관리 (WorkerCard, AddWorkerModal, WorkScheduleCalendarModal 등)
+│   │   ├── remittance/      # 송금관리
 │   │   └── mypage/          # 고용주 마이페이지 (EmployerMyPageDrawer, ReceivedRequestCard, AddWorkplaceModal 등)
 │   ├── layout/       # Header
 │   ├── mypage/       # 공통 마이페이지 (Drawer, ProfileCard, MenuButton, SentRequestCard 등)
@@ -66,8 +70,8 @@ src/
 │       ├── monthlyCalendar/ # 월간 캘린더
 │       └── salary/          # 급여명세서 (WorkplaceTabSelector 등)
 ├── hooks/
-│   ├── common/       # useOnboardingStatus, useLogoutHandler
-│   ├── employer/     # useWorkplaceManagement, useWorkplaceContracts, useAddWorker, useReceivedRequests
+│   ├── common/       # useOnboardingStatus, useLogoutHandler, useNotices, usePickerState
+│   ├── employer/     # useWorkplaceManagement, useWorkplaceContracts, useAddWorker, useReceivedRequests, useEmployerDrawer, useEmployerDailyWorkRecords
 │   └── worker/       # useWorkRecords, useCorrectionRequest, useUserData, useSalaryStatement 등
 ├── navigation/       # RootNavigator, WorkerStack, EmployerStack, SignUpNavigator, OnboardingStack
 ├── screens/
@@ -96,9 +100,13 @@ src/
 - 마이페이지: 프로필 수정, 근무지 관리, 보낸 근무요청 보기
 
 **고용주(Employer)**:
+- 홈: 일간 캘린더, 근무 추가/수정
 - 직원관리: 근무지별 근무자 목록, 계약 수정, 근무자 추가/퇴사
 - 근무지 관리: 근무지 CRUD (카카오 주소 검색 연동)
 - 마이페이지: 프로필 수정, 받은 근무요청 보기 (승인/거절, 페이지네이션)
+
+**공통**:
+- 공지 게시판: 공지 작성/수정/삭제, 카테고리 필터, 상세 보기 바텀시트
 
 ### 인증
 - 카카오 로그인/회원가입 (`@react-native-seoul/kakao-login`)
@@ -143,7 +151,9 @@ Welcome (카카오 로그인)
 | 컴포넌트 | 설명 |
 |---------|------|
 | `Text` | **필수 사용.** react-native의 Text 대신 사용 (Pretendard 폰트). weight: Regular/Medium/SemiBold/Bold/ExtraBold |
-| `BottomSheetModal` | 하단 슬라이드업 모달 (overlay + slide-up 애니메이션) |
+| `BottomSheetModal` | 하단 슬라이드업 모달 (overlay + slide-up 애니메이션, 키보드 자동 회피, 스와이프 닫기) |
+| `NoticeBoard` | 공지 게시판 (고용주/근로자 공용, 카테고리 필터) |
+| `NoticeCard` | 공지 카드 (제목, 카테고리, 날짜) |
 | `WheelPicker` | iOS 스타일 드럼 롤 피커. **주의: ScrollView 안에 넣으면 VirtualizedList 중첩 경고** |
 | `MonthlyCalendar` | 월간 캘린더 그리드 (날짜별 dot 표시, 오늘/선택 하이라이트) |
 | `MonthlyCalendarNav` | 월간 캘린더 상단 네비게이션 (이전/다음 달) |
@@ -171,6 +181,15 @@ Welcome (카카오 로그인)
 | `useWorkplaceContracts` | 근무지별 근무자 목록 + 계약 상세 병렬 조회 + 퇴사/수정 |
 | `useAddWorker` | 근무자 추가 2단계 폼 (코드 검색 → 시급/근무시간 설정) |
 | `useReceivedRequests` | 받은 정정요청 목록(페이징)/상세/승인/거절 관리 |
+| `useEmployerDrawer` | 고용주 Drawer 보일러플레이트 추출 |
+| `useEmployerDailyWorkRecords` | 고용주 일간 근무기록 조회 |
+| `useWorkTimePicker` | 근무시간 피커 상태 관리 |
+
+**공통:**
+| 훅 | 설명 |
+|---|------|
+| `useNotices` | 공지 목록/상세/CRUD 관리 |
+| `usePickerState` | Picker 로직 공통 훅 |
 
 ### 참조할 웹 파일 위치
 
@@ -207,6 +226,9 @@ eas build --platform ios  # 빌드
 - [x] 고용주 마이페이지 Drawer + 프로필 수정
 - [x] 고용주 받은 근무요청 (사업장별 탭, 상태 필터, 페이지네이션, 승인/거절)
 - [x] 공통 컴포넌트 (Pagination, WorkplaceTabSelector 등)
+- [x] 고용주 일간 캘린더 화면 (근무 추가/수정 모달)
+- [x] 공지 게시판 (공지 작성/수정/삭제, 카테고리 필터, 상세 바텀시트)
+- [x] BottomSheetModal 스와이프 닫기 + 키보드 회피 버그 수정
 
 ### TODO
 - [ ] 고용주 송금관리 화면 구현

--- a/README.md
+++ b/README.md
@@ -22,19 +22,21 @@ src/
 │   ├── user/         # 사용자 API (프로필 조회/수정)
 │   ├── worker/       # 근로자 API (계약, 근무기록, 정정요청, 급여, 송금)
 │   ├── employer/     # 고용주 API (근무지 CRUD, 계약 CRUD, 정정요청 승인/거절)
+│   ├── notice/       # 공지 API (공지 CRUD)
 │   └── kakao/        # 카카오 API (주소 검색)
 ├── assets/           # 폰트, 이미지
 ├── components/
-│   ├── common/       # Text, PrimaryButton, BottomSheetModal, WheelPicker, MonthlyCalendar, Pagination 등
-│   ├── employer/     # 고용주 전용 (직원관리, 마이페이지)
+│   ├── common/       # Text, PrimaryButton, BottomSheetModal, WheelPicker, MonthlyCalendar, Pagination, NoticeBoard 등
+│   │   └── notice/          # 공지 컴포넌트 (작성/수정/상세 모달, 카테고리 선택)
+│   ├── employer/     # 고용주 전용 (홈, 직원관리, 송금관리, 마이페이지)
 │   ├── layout/       # Header
 │   ├── mypage/       # 공통 마이페이지 (Drawer, ProfileCard, SentRequestCard 등)
 │   ├── signup/       # 회원가입
 │   ├── skeleton/     # 로딩 스켈레톤
 │   └── worker/       # 근로자 전용 (주간/월간 캘린더, 급여명세서)
 ├── hooks/
-│   ├── common/       # useOnboardingStatus, useLogoutHandler
-│   ├── employer/     # useWorkplaceManagement, useWorkplaceContracts, useAddWorker, useReceivedRequests
+│   ├── common/       # useOnboardingStatus, useLogoutHandler, useNotices, usePickerState
+│   ├── employer/     # useWorkplaceManagement, useWorkplaceContracts, useAddWorker, useReceivedRequests, useEmployerDailyWorkRecords
 │   └── worker/       # useWorkRecords, useCorrectionRequest, useUserData, useSalaryStatement 등
 ├── navigation/       # RootNavigator, WorkerStack, EmployerStack, SignUpNavigator, OnboardingStack
 ├── screens/
@@ -57,10 +59,14 @@ src/
 - 마이페이지: Drawer 메뉴, 프로필 수정, 근무지 관리, 보낸 요청, 회원탈퇴
 
 ### 고용주 기능
+- 홈: 일간 캘린더, 근무 추가/수정 모달
 - 직원관리: 근무지별 근무자 목록 조회, Accordion 카드 (시급/급여지급일/근무시간 편집), 퇴사처리
 - 근무자 추가: 2단계 플로우 (근무자 코드 검색 → 근무시간 설정), 근무 스케줄 타임라인 차트 프리뷰
 - 근무지 관리: 근무지 CRUD, 카카오 주소 검색 연동
 - 마이페이지: 프로필 수정, 받은 근무요청 보기 (사업장별 탭, 상태 필터, 페이지네이션, 승인/거절)
+
+### 공통 기능
+- 공지 게시판: 공지 작성/수정/삭제, 카테고리 필터, 상세 보기 바텀시트 (고용주/근로자 공용)
 
 ### 인증
 - 카카오 네이티브 SDK 로그인 (`@react-native-seoul/kakao-login`)

--- a/src/components/common/BottomSheetModal.tsx
+++ b/src/components/common/BottomSheetModal.tsx
@@ -11,7 +11,7 @@ import {
 	Animated,
 	PanResponder,
 	Dimensions,
-	KeyboardAvoidingView,
+	Keyboard,
 	Platform,
 	type DimensionValue,
 } from "react-native";
@@ -36,6 +36,7 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
 	const slideAnim = useRef(new Animated.Value(0)).current;
 	const overlayAnim = useRef(new Animated.Value(0)).current;
 	const panY = useRef(new Animated.Value(0)).current;
+	const keyboardOffset = useRef(new Animated.Value(0)).current;
 
 	useEffect(() => {
 		if (visible) {
@@ -57,10 +58,40 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
 			slideAnim.setValue(0);
 			overlayAnim.setValue(0);
 			panY.setValue(0);
+			keyboardOffset.setValue(0);
 		}
 	}, [visible]);
 
+	useEffect(() => {
+		const showEvent =
+			Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
+		const hideEvent =
+			Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
+
+		const showSub = Keyboard.addListener(showEvent, (e) => {
+			Animated.timing(keyboardOffset, {
+				toValue: -e.endCoordinates.height,
+				duration: 150,
+				useNativeDriver: true,
+			}).start();
+		});
+
+		const hideSub = Keyboard.addListener(hideEvent, () => {
+			Animated.timing(keyboardOffset, {
+				toValue: 0,
+				duration: 150,
+				useNativeDriver: true,
+			}).start();
+		});
+
+		return () => {
+			showSub.remove();
+			hideSub.remove();
+		};
+	}, []);
+
 	const handleClose = useCallback(() => {
+		Keyboard.dismiss();
 		Animated.parallel([
 			Animated.timing(overlayAnim, {
 				toValue: 0,
@@ -74,6 +105,7 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
 			}),
 		]).start(() => {
 			panY.setValue(0);
+			keyboardOffset.setValue(0);
 			onClose();
 		});
 	}, [onClose]);
@@ -108,7 +140,10 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
 		outputRange: [SCREEN_HEIGHT, 0],
 	});
 
-	const combinedTranslateY = Animated.add(translateY, panY);
+	const combinedTranslateY = Animated.add(
+		Animated.add(translateY, panY),
+		keyboardOffset
+	);
 
 	return (
 		<Modal
@@ -117,48 +152,40 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
 			animationType="none"
 			onRequestClose={handleClose}
 		>
-			<KeyboardAvoidingView
-				style={styles.keyboardAvoid}
-				behavior={Platform.OS === "ios" ? "padding" : "height"}
-			>
-				<View style={styles.overlay}>
-					<Animated.View
-						style={[
-							styles.overlayBackground,
-							{ opacity: overlayAnim },
-						]}
+			<View style={styles.overlay}>
+				<Animated.View
+					style={[
+						styles.overlayBackground,
+						{ opacity: overlayAnim },
+					]}
+				>
+					<TouchableOpacity
+						style={StyleSheet.absoluteFill}
+						activeOpacity={1}
+						onPress={handleClose}
+					/>
+				</Animated.View>
+				<Animated.View
+					style={[
+						styles.modalContainer,
+						{ maxHeight },
+						{ transform: [{ translateY: combinedTranslateY }] },
+					]}
+				>
+					<View
+						{...panResponder.panHandlers}
+						style={styles.handleArea}
 					>
-						<TouchableOpacity
-							style={StyleSheet.absoluteFill}
-							activeOpacity={1}
-							onPress={handleClose}
-						/>
-					</Animated.View>
-					<Animated.View
-						style={[
-							styles.modalContainer,
-							{ maxHeight },
-							{ transform: [{ translateY: combinedTranslateY }] },
-						]}
-					>
-						<View
-							{...panResponder.panHandlers}
-							style={styles.handleArea}
-						>
-							<View style={styles.handle} />
-						</View>
-						{children}
-					</Animated.View>
-				</View>
-			</KeyboardAvoidingView>
+						<View style={styles.handle} />
+					</View>
+					{children}
+				</Animated.View>
+			</View>
 		</Modal>
 	);
 };
 
 const styles = StyleSheet.create({
-	keyboardAvoid: {
-		flex: 1,
-	},
 	overlay: {
 		flex: 1,
 		justifyContent: "flex-end",

--- a/src/components/common/BottomSheetModal.tsx
+++ b/src/components/common/BottomSheetModal.tsx
@@ -22,6 +22,8 @@ interface BottomSheetModalProps {
 	onClose: () => void;
 	children: React.ReactNode;
 	maxHeight?: DimensionValue;
+	/** 키보드 표시 시 모달이 올라가는 비율 (0: 안 올라감 ~ 1: 키보드 높이만큼 올라감) */
+	keyboardOffsetRatio?: number;
 }
 
 const SCREEN_HEIGHT = Dimensions.get("window").height;
@@ -32,6 +34,7 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
 	onClose,
 	children,
 	maxHeight = "90%",
+	keyboardOffsetRatio = 1,
 }) => {
 	const slideAnim = useRef(new Animated.Value(0)).current;
 	const overlayAnim = useRef(new Animated.Value(0)).current;
@@ -72,7 +75,7 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
 
 		const showSub = Keyboard.addListener(showEvent, (e) => {
 			Animated.timing(keyboardOffset, {
-				toValue: -e.endCoordinates.height,
+				toValue: -e.endCoordinates.height * keyboardOffsetRatio,
 				duration: 150,
 				useNativeDriver: true,
 			}).start();

--- a/src/components/common/BottomSheetModal.tsx
+++ b/src/components/common/BottomSheetModal.tsx
@@ -63,6 +63,8 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
 	}, [visible]);
 
 	useEffect(() => {
+		if (!visible) return;
+
 		const showEvent =
 			Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
 		const hideEvent =
@@ -88,7 +90,7 @@ const BottomSheetModal: React.FC<BottomSheetModalProps> = ({
 			showSub.remove();
 			hideSub.remove();
 		};
-	}, []);
+	}, [visible]);
 
 	const handleClose = useCallback(() => {
 		Keyboard.dismiss();

--- a/src/components/common/notice/NoticeCreateModal.tsx
+++ b/src/components/common/notice/NoticeCreateModal.tsx
@@ -93,7 +93,7 @@ const NoticeCreateModal: React.FC<NoticeCreateModalProps> = ({
 	);
 
 	return (
-		<BottomSheetModal visible={visible} onClose={handleClose}>
+		<BottomSheetModal visible={visible} onClose={handleClose} keyboardOffsetRatio={0.7}>
 			{/* 스크롤 가능한 폼 영역 */}
 			<ScrollView
 				showsVerticalScrollIndicator={false}

--- a/src/components/common/notice/NoticeEditSheet.tsx
+++ b/src/components/common/notice/NoticeEditSheet.tsx
@@ -145,7 +145,7 @@ const NoticeEditSheet: React.FC<NoticeEditSheetProps> = ({
 	if (!notice) return null;
 
 	return (
-		<BottomSheetModal visible={visible} onClose={onClose}>
+		<BottomSheetModal visible={visible} onClose={onClose} keyboardOffsetRatio={0.8}>
 			{/* 스크롤 가능한 폼 영역 */}
 			<ScrollView
 				showsVerticalScrollIndicator={false}

--- a/src/components/employer/mypage/AddWorkplaceModal.tsx
+++ b/src/components/employer/mypage/AddWorkplaceModal.tsx
@@ -125,7 +125,7 @@ const AddWorkplaceModal: React.FC<AddWorkplaceModalProps> = ({
 	};
 
 	return (
-		<BottomSheetModal visible={visible} onClose={handleClose} maxHeight="85%">
+		<BottomSheetModal visible={visible} onClose={handleClose} maxHeight="85%" keyboardOffsetRatio={0.4}>
 			<ScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
 				<Text weight="ExtraBold" style={styles.title}>
 					새로운 근무지 추가하기

--- a/src/components/mypage/AccountEditModal.tsx
+++ b/src/components/mypage/AccountEditModal.tsx
@@ -47,7 +47,7 @@ const AccountEditModal: React.FC<AccountEditModalProps> = ({
   };
 
   return (
-    <BottomSheetModal visible={visible} onClose={onClose} maxHeight="60%">
+    <BottomSheetModal visible={visible} onClose={onClose} maxHeight="60%" keyboardOffsetRatio={0.8}>
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}

--- a/src/components/mypage/ProfileEditModal.tsx
+++ b/src/components/mypage/ProfileEditModal.tsx
@@ -47,7 +47,7 @@ const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
   }, [visible]);
 
   return (
-    <BottomSheetModal visible={visible} onClose={onClose} maxHeight="85%">
+    <BottomSheetModal visible={visible} onClose={onClose} maxHeight="85%" keyboardOffsetRatio={0.8}>
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}


### PR DESCRIPTION
## 📌 Issue number and Link
closed #32

## ✏️ Summary
`BottomSheetModal` 내부 `TextInput` 포커스 시 모달이 화면 밖으로 밀려나는 키보드 버그 수정

## 📝 Changes
- `KeyboardAvoidingView` 제거, `Keyboard` 리스너 기반 키보드 회피로 대체
- `keyboardOffset` Animated.Value 추가하여 키보드 높이만큼 모달 translateY 조정
- 모달이 `visible`일 때만 키보드 리스너 등록/해제하도록 최적화
- 모달 닫기 시 `Keyboard.dismiss()` 호출
- CLAUDE.md, README.md 최신 구현 현황 반영 (공지 게시판, 고용주 일간 캘린더 등)

### 변경 원인
`KeyboardAvoidingView`(behavior="padding")가 JS 레이아웃을 조작하는데, `Animated.View`의 `useNativeDriver: true` transform과 충돌하여 모달이 이중으로 밀려나는 현상 발생. 동일한 네이티브 레이어에서 `Animated.timing`으로 키보드 대응하도록 변경.

### 영향 범위
`BottomSheetModal`을 사용하는 30개 파일 모두 자동 적용 (개별 수정 불필요)

## 🔎 PR Type
- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [x] Documentation content changes

## 📸 Screenshot