### PR TITLE
[Refactor] 에러 메시지 표준화 (Alert/Toast 규칙 적용, 서버 메시지 노출 제거)

### DIFF
--- a/src/components/employer/home/EmployerAddWorkModal.tsx
+++ b/src/components/employer/home/EmployerAddWorkModal.tsx
@@ -7,7 +7,7 @@ import {
   ActivityIndicator,
   Alert,
 } from "react-native";
-import { showError } from "../../../utils/alert";
+import { showSuccess, showError } from "../../../utils/alert";
 import { Feather } from "@expo/vector-icons";
 import PrimaryButton from "../../common/PrimaryButton";
 import { Text } from "../../common/Text";
@@ -141,6 +141,7 @@ const EmployerAddWorkModal: React.FC<EmployerAddWorkModalProps> = ({
         endTime,
         breakMinutes,
       });
+      showSuccess("추가 완료", "근무가 추가되었습니다.");
       onSuccess();
       onClose();
     } catch {

--- a/src/components/employer/home/EmployerAddWorkModal.tsx
+++ b/src/components/employer/home/EmployerAddWorkModal.tsx
@@ -7,7 +7,7 @@ import {
   ActivityIndicator,
   Alert,
 } from "react-native";
-import { isAxiosError } from "axios";
+import { showError } from "../../../utils/alert";
 import { Feather } from "@expo/vector-icons";
 import PrimaryButton from "../../common/PrimaryButton";
 import { Text } from "../../common/Text";
@@ -143,11 +143,8 @@ const EmployerAddWorkModal: React.FC<EmployerAddWorkModalProps> = ({
       });
       onSuccess();
       onClose();
-    } catch (error) {
-      const message = isAxiosError(error)
-        ? (error.response?.data?.error?.message ?? "근무 추가에 실패했습니다.")
-        : "근무 추가에 실패했습니다.";
-      Alert.alert("추가 실패", message);
+    } catch {
+      showError("추가 실패", "근무 추가에 실패했습니다.");
     } finally {
       setIsSubmitting(false);
     }

--- a/src/components/employer/home/EmployerAddWorkModal.tsx
+++ b/src/components/employer/home/EmployerAddWorkModal.tsx
@@ -123,7 +123,7 @@ const EmployerAddWorkModal: React.FC<EmployerAddWorkModalProps> = ({
 
   const handleSubmit = async () => {
     if (!selectedContractId) {
-      Alert.alert("알림", "근무자를 선택해주세요.");
+      Alert.alert("입력 확인", "근무자를 선택해주세요.");
       return;
     }
     const year = parsedDate.getFullYear();

--- a/src/components/employer/home/EmployerEditWorkModal.tsx
+++ b/src/components/employer/home/EmployerEditWorkModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
-import { View, StyleSheet, TouchableOpacity, Alert } from "react-native";
-import { isAxiosError } from "axios";
+import { View, StyleSheet, TouchableOpacity } from "react-native";
+import { showSuccess, showError } from "../../../utils/alert";
 import { Feather } from "@expo/vector-icons";
 import PrimaryButton from "../../common/PrimaryButton";
 import { Text } from "../../common/Text";
@@ -49,14 +49,11 @@ const EmployerEditWorkModal: React.FC<EmployerEditWorkModalProps> = ({
     setIsSubmitting(true);
     try {
       await updateWorkRecord(record.id, { startTime, endTime, breakMinutes });
-      Alert.alert("완료", "근무 정보가 수정되었습니다.");
+      showSuccess("수정 완료", "근무 정보가 수정되었습니다.");
       onSuccess();
       onClose();
-    } catch (error) {
-      const message = isAxiosError(error)
-        ? (error.response?.data?.error?.message ?? "근무 수정에 실패했습니다.")
-        : "근무 수정에 실패했습니다.";
-      Alert.alert("수정 실패", message);
+    } catch {
+      showError("수정 실패", "근무 수정에 실패했습니다.");
     } finally {
       setIsSubmitting(false);
     }

--- a/src/components/employer/home/EmployerWorkerListSection.tsx
+++ b/src/components/employer/home/EmployerWorkerListSection.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { View, TouchableOpacity, StyleSheet, Alert } from "react-native";
-import { isAxiosError } from "axios";
+import { View, TouchableOpacity, StyleSheet } from "react-native";
+import { showError } from "../../../utils/alert";
 import { Text } from "../../common/Text";
 import EmployerWorkerCard from "./EmployerWorkerCard";
 import EmployerEditWorkModal from "./EmployerEditWorkModal";
@@ -33,12 +33,9 @@ const EmployerWorkerListSection: React.FC<EmployerWorkerListSectionProps> = ({
     onDeleteItem(id);
     try {
       await deleteWorkRecord(id);
-    } catch (error) {
+    } catch {
       onRefetch();
-      const message = isAxiosError(error)
-        ? (error.response?.data?.error?.message ?? "삭제에 실패했습니다.")
-        : "삭제에 실패했습니다.";
-      Alert.alert("삭제 실패", message);
+      showError("삭제 실패", "삭제에 실패했습니다.");
     }
   };
 

--- a/src/components/employer/mypage/AddWorkplaceModal.tsx
+++ b/src/components/employer/mypage/AddWorkplaceModal.tsx
@@ -69,7 +69,7 @@ const AddWorkplaceModal: React.FC<AddWorkplaceModalProps> = ({
 	const handleSearch = async () => {
 		const query = searchQuery.trim();
 		if (!query) {
-			Alert.alert("검색어 입력", "주소를 입력해주세요.");
+			Alert.alert("입력 확인", "주소를 입력해주세요.");
 			return;
 		}
 

--- a/src/components/employer/mypage/AddWorkplaceModal.tsx
+++ b/src/components/employer/mypage/AddWorkplaceModal.tsx
@@ -9,6 +9,7 @@ import {
 	ActivityIndicator,
 	Switch,
 } from "react-native";
+import { showSuccess, showError, showWarning } from "../../../utils/alert";
 import BottomSheetModal from "../../common/BottomSheetModal";
 import PrimaryButton from "../../common/PrimaryButton";
 import { Text } from "../../common/Text";
@@ -76,14 +77,14 @@ const AddWorkplaceModal: React.FC<AddWorkplaceModalProps> = ({
 		try {
 			const results = await searchAddress(query);
 			if (results.length === 0) {
-				Alert.alert("검색 결과 없음", "검색 결과가 없습니다. 다른 주소를 입력해주세요.");
+				showWarning("검색 결과 없음", "검색 결과가 없습니다. 다른 주소를 입력해주세요.");
 				setShowResults(false);
 			} else {
 				setSearchResults(results);
 				setShowResults(true);
 			}
 		} catch {
-			Alert.alert("검색 실패", "주소 검색 중 오류가 발생했습니다.");
+			showError("검색 실패", "주소 검색 중 오류가 발생했습니다.");
 		} finally {
 			setIsSearching(false);
 		}
@@ -110,15 +111,15 @@ const AddWorkplaceModal: React.FC<AddWorkplaceModalProps> = ({
 			});
 
 			if (res.success) {
-				Alert.alert("등록 완료", "새로운 근무지가 등록되었습니다.");
+				showSuccess("등록 완료", "새로운 근무지가 등록되었습니다.");
 				resetForm();
 				onClose();
 				onSuccess?.();
 			} else {
-				Alert.alert("등록 실패", res.error?.message || "근무지 등록에 실패했습니다.");
+				showError("등록 실패", "근무지 등록에 실패했습니다.");
 			}
-		} catch (error: any) {
-			Alert.alert("등록 실패", error?.message || "근무지 등록 중 오류가 발생했습니다.");
+		} catch {
+			showError("등록 실패", "근무지 등록 중 오류가 발생했습니다.");
 		} finally {
 			setIsLoading(false);
 		}

--- a/src/components/employer/worker-manage/AddWorkerModal.tsx
+++ b/src/components/employer/worker-manage/AddWorkerModal.tsx
@@ -7,10 +7,10 @@ import {
   ScrollView,
   ActivityIndicator,
   StyleSheet,
-  Alert,
   useWindowDimensions,
 } from "react-native";
 import { isAxiosError } from "axios";
+import { showSuccess, showError } from "../../../utils/alert";
 import { Feather } from "@expo/vector-icons";
 import { Text } from "../../common/Text";
 import BottomSheetModal from "../../common/BottomSheetModal";
@@ -80,18 +80,18 @@ const AddWorkerModal: React.FC<AddWorkerModalProps> = ({
   const handleConfirmSubmit = async () => {
     try {
       const contractId = await handleSubmit(workplaceId);
-      Alert.alert("추가 성공", "근무자가 추가되었습니다.");
+      showSuccess("추가 완료", "근무자가 추가되었습니다.");
       reset();
       onSuccess(contractId);
     } catch (error) {
       if (isAxiosError(error) && error.response?.status === 400) {
         const errorCode = (error.response.data as { error?: { code?: string } })?.error?.code;
         if (errorCode === "DUPLICATE_CONTRACT") {
-          Alert.alert("추가 실패", "이미 해당 사업장에 계약이 존재하는 근로자입니다.");
+          showError("추가 실패", "이미 해당 사업장에 계약이 존재하는 근로자입니다.");
           return;
         }
       }
-      Alert.alert("추가 실패", "근무자 추가가 실패하였습니다.");
+      showError("추가 실패", "근무자 추가에 실패했습니다.");
     }
   };
 

--- a/src/components/employer/worker-manage/WorkerCard.tsx
+++ b/src/components/employer/worker-manage/WorkerCard.tsx
@@ -117,11 +117,11 @@ const WorkerCard: React.FC<WorkerCardProps> = ({
     const day = parseInt(paymentDay, 10);
 
     if (isNaN(wage) || wage <= 0) {
-      Alert.alert("입력 오류", "올바른 시급을 입력해주세요.");
+      Alert.alert("입력 확인", "올바른 시급을 입력해주세요.");
       return;
     }
     if (isNaN(day) || day < 1 || day > 31) {
-      Alert.alert("입력 오류", "급여지급일은 1~31 사이로 입력해주세요.");
+      Alert.alert("입력 확인", "급여지급일은 1~31 사이로 입력해주세요.");
       return;
     }
 

--- a/src/hooks/common/useLogoutHandler.ts
+++ b/src/hooks/common/useLogoutHandler.ts
@@ -1,6 +1,7 @@
 import { Alert } from "react-native";
 import { logout } from "../../api/auth";
 import { unregisterPushToken } from "../../utils/pushToken";
+import { showSuccess, showError } from "../../utils/alert";
 
 /**
  * 로그아웃 핸들러
@@ -25,12 +26,9 @@ export const useLogoutHandler = (
             try {
               await unregisterPushToken();
               await logout();
-              Alert.alert("로그아웃", "로그아웃이 완료되었습니다.");
-            } catch (error: any) {
-              Alert.alert(
-                "로그아웃 실패",
-                error?.message || "로그아웃 처리 중 오류가 발생했습니다."
-              );
+              showSuccess("로그아웃이 완료되었습니다.");
+            } catch {
+              showError("로그아웃 실패", "로그아웃 처리 중 오류가 발생했습니다.");
             } finally {
               navigation.getParent()?.reset({ index: 0, routes: [{ name: "Welcome" }] });
             }

--- a/src/hooks/common/useLogoutHandler.ts
+++ b/src/hooks/common/useLogoutHandler.ts
@@ -26,7 +26,7 @@ export const useLogoutHandler = (
             try {
               await unregisterPushToken();
               await logout();
-              showSuccess("로그아웃이 완료되었습니다.");
+              showSuccess("로그아웃 완료", "로그아웃이 완료되었습니다.");
             } catch {
               showError("로그아웃 실패", "로그아웃 처리 중 오류가 발생했습니다.");
             } finally {

--- a/src/hooks/employer/useAddWorker.ts
+++ b/src/hooks/employer/useAddWorker.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from "react";
 import { Alert } from "react-native";
+import { showError } from "../../utils/alert";
 import type { WorkScheduleRow } from "../../types/employer/employer.types";
 import type { SearchedWorker, WorkSchedule } from "../../api/employer/types";
 import { getWorkerByCode } from "../../api/worker";
@@ -44,11 +45,11 @@ const useAddWorker = () => {
       if (workerData && workerData.id) {
         setSearchedWorker(workerData);
       } else {
-        Alert.alert("검색 실패", "해당 근무자 코드를 찾을 수 없습니다.");
+        showError("검색 실패", "해당 근무자 코드를 찾을 수 없습니다.");
         setSearchedWorker(null);
       }
     } catch {
-      Alert.alert("검색 실패", "해당 근무자 코드를 찾을 수 없습니다.");
+      showError("검색 실패", "해당 근무자 코드를 찾을 수 없습니다.");
       setSearchedWorker(null);
     } finally {
       setIsSearching(false);

--- a/src/hooks/employer/useAddWorker.ts
+++ b/src/hooks/employer/useAddWorker.ts
@@ -34,7 +34,7 @@ const useAddWorker = () => {
   const handleSearch = useCallback(async () => {
     if (isSearching) return;
     if (!workerCode.trim()) {
-      Alert.alert("입력 오류", "근무자 코드를 입력해주세요.");
+      Alert.alert("입력 확인", "근무자 코드를 입력해주세요.");
       return;
     }
     setIsSearching(true);

--- a/src/hooks/employer/useReceivedRequests.ts
+++ b/src/hooks/employer/useReceivedRequests.ts
@@ -194,7 +194,7 @@ export function useReceivedRequests(): UseReceivedRequestsReturn {
 							setDetail(null);
 							await fetchRequests();
 						} else {
-							showError(response.error?.message ?? "승인에 실패했습니다.");
+							showError("승인 실패", "요청 승인에 실패했습니다.");
 						}
 					} catch {
 						showError("승인 처리에 실패했습니다.");
@@ -225,7 +225,7 @@ export function useReceivedRequests(): UseReceivedRequestsReturn {
 							setDetail(null);
 							await fetchRequests();
 						} else {
-							showError(response.error?.message ?? "거절에 실패했습니다.");
+							showError("거절 실패", "요청 거절에 실패했습니다.");
 						}
 					} catch {
 						showError("거절 처리에 실패했습니다.");

--- a/src/hooks/employer/useReceivedRequests.ts
+++ b/src/hooks/employer/useReceivedRequests.ts
@@ -189,7 +189,7 @@ export function useReceivedRequests(): UseReceivedRequestsReturn {
 					try {
 						const response = await approveCorrectionRequest(id);
 						if (response.success) {
-							showSuccess("요청이 승인되었습니다.");
+							showSuccess("승인 완료", "요청이 승인되었습니다.");
 							setExpandedId(null);
 							setDetail(null);
 							await fetchRequests();
@@ -197,7 +197,7 @@ export function useReceivedRequests(): UseReceivedRequestsReturn {
 							showError("승인 실패", "요청 승인에 실패했습니다.");
 						}
 					} catch {
-						showError("승인 처리에 실패했습니다.");
+						showError("승인 실패", "승인 처리에 실패했습니다.");
 					} finally {
 						setProcessingId(null);
 						setProcessingAction(null);
@@ -220,7 +220,7 @@ export function useReceivedRequests(): UseReceivedRequestsReturn {
 					try {
 						const response = await rejectCorrectionRequest(id);
 						if (response.success) {
-							showSuccess("요청이 거절되었습니다.");
+							showSuccess("거절 완료", "요청이 거절되었습니다.");
 							setExpandedId(null);
 							setDetail(null);
 							await fetchRequests();
@@ -228,7 +228,7 @@ export function useReceivedRequests(): UseReceivedRequestsReturn {
 							showError("거절 실패", "요청 거절에 실패했습니다.");
 						}
 					} catch {
-						showError("거절 처리에 실패했습니다.");
+						showError("거절 실패", "거절 처리에 실패했습니다.");
 					} finally {
 						setProcessingId(null);
 						setProcessingAction(null);

--- a/src/hooks/employer/useWorkplaceManagement.ts
+++ b/src/hooks/employer/useWorkplaceManagement.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { Alert } from "react-native";
+import { showError } from "../../utils/alert";
 import type { WorkplaceDetails } from "../../api/employer/types";
 import {
   getWorkplaces,
@@ -150,9 +151,8 @@ export function useWorkplaceManagement({
       setNewWorkplaceIsSmallBusiness(false);
 
       onWorkplaceChanged?.(createdWorkplace.id);
-    } catch (error) {
-      const err = error as { message?: string };
-      Alert.alert("추가 실패", err.message || "근무지 추가 중 오류가 발생했습니다.");
+    } catch {
+      showError("추가 실패", "근무지 추가 중 오류가 발생했습니다.");
     }
   };
 
@@ -181,7 +181,7 @@ export function useWorkplaceManagement({
           onPress: async () => {
             const updatedWorkplaces = workplaces.filter((wp) => wp.id !== selectedWorkplaceId);
             if (updatedWorkplaces.length === 0) {
-              Alert.alert("오류", "최소 하나의 근무지는 필요합니다.");
+              showError("삭제 실패", "최소 하나의 근무지는 필요합니다.");
               return;
             }
             try {
@@ -190,9 +190,8 @@ export function useWorkplaceManagement({
               const firstWorkplace = updatedWorkplaces[0];
               if (firstWorkplace) setSelectedWorkplaceId(firstWorkplace.id);
               onWorkplaceDeleted?.(selectedWorkplaceId);
-            } catch (error) {
-              const err = error as { message?: string };
-              Alert.alert("삭제 실패", err.message || "근무지 삭제 중 오류가 발생했습니다.");
+            } catch {
+              showError("삭제 실패", "근무지 삭제 중 오류가 발생했습니다.");
             }
           },
         },
@@ -251,9 +250,8 @@ export function useWorkplaceManagement({
       setEditingWorkplace(null);
       setSelectedWorkplaceForEdit(null);
       onWorkplaceChanged?.(editingWorkplace.id);
-    } catch (error) {
-      const err = error as { message?: string };
-      Alert.alert("수정 실패", err.message || "근무지 수정 중 오류가 발생했습니다.");
+    } catch {
+      showError("수정 실패", "근무지 수정 중 오류가 발생했습니다.");
     }
   };
 

--- a/src/hooks/employer/useWorkplaceManagement.ts
+++ b/src/hooks/employer/useWorkplaceManagement.ts
@@ -124,12 +124,12 @@ export function useWorkplaceManagement({
     const workplaceName = newWorkplaceName.trim();
 
     if (!workplaceName) {
-      Alert.alert("입력 오류", "근무지 이름을 입력해주세요.");
+      Alert.alert("입력 확인", "근무지 이름을 입력해주세요.");
       return;
     }
 
     if (workplaces.some((wp) => wp.name === workplaceName)) {
-      Alert.alert("입력 오류", "이미 존재하는 근무지입니다.");
+      Alert.alert("입력 확인", "이미 존재하는 근무지입니다.");
       return;
     }
 
@@ -214,7 +214,7 @@ export function useWorkplaceManagement({
     if (!editingWorkplace) return;
 
     if (!editingWorkplace.name.trim()) {
-      Alert.alert("입력 오류", "근무지 이름을 입력해주세요.");
+      Alert.alert("입력 확인", "근무지 이름을 입력해주세요.");
       return;
     }
 
@@ -222,7 +222,7 @@ export function useWorkplaceManagement({
       (wp) => wp.name === editingWorkplace.name.trim() && wp.id !== editingWorkplace.id
     );
     if (isDuplicate) {
-      Alert.alert("입력 오류", "이미 존재하는 근무지입니다.");
+      Alert.alert("입력 확인", "이미 존재하는 근무지입니다.");
       return;
     }
 

--- a/src/hooks/worker/useAccountEdit.ts
+++ b/src/hooks/worker/useAccountEdit.ts
@@ -79,12 +79,7 @@ export function useAccountEdit({ worker, onSuccess, onClose }: UseAccountEditPar
         onSuccess();
         onClose();
       } else {
-        const fieldErrors = response.error?.fieldErrors;
-        if (fieldErrors && fieldErrors.length > 0) {
-          showError(fieldErrors[0].message);
-        } else {
-          showError(response.error?.message ?? "계좌 정보 수정에 실패했습니다.");
-        }
+        showError("수정 실패", "계좌 정보 수정에 실패했습니다.");
       }
     } catch (error) {
       console.error("계좌 정보 수정 실패:", error);

--- a/src/hooks/worker/useAccountEdit.ts
+++ b/src/hooks/worker/useAccountEdit.ts
@@ -83,7 +83,7 @@ export function useAccountEdit({ worker, onSuccess, onClose }: UseAccountEditPar
       }
     } catch (error) {
       console.error("계좌 정보 수정 실패:", error);
-      showError("계좌 정보 수정에 실패했습니다.");
+      showError("수정 실패", "계좌 정보 수정에 실패했습니다.");
     } finally {
       setIsSubmitting(false);
     }

--- a/src/hooks/worker/useCorrectionRequest.ts
+++ b/src/hooks/worker/useCorrectionRequest.ts
@@ -4,8 +4,8 @@
  * 주간캘린더, 월간캘린더 등 여러 스크린에서 재사용 가능.
  */
 import { useState, useCallback } from "react";
-import { Alert } from "react-native";
 import { createCorrectionRequest } from "../../api/worker";
+import { showSuccess, showError } from "../../utils/alert";
 import type { WorkItem } from "../../types/worker.types";
 
 const useCorrectionRequest = () => {
@@ -47,13 +47,9 @@ const useCorrectionRequest = () => {
 					...data,
 				});
 				setCorrectionModalVisible(false);
-				Alert.alert("요청 완료", "근무 기록 정정 요청이 전송되었습니다.");
-			} catch (error) {
-				const message =
-					error instanceof Error
-						? error.message
-						: "요청에 실패했습니다. 다시 시도해주세요.";
-				Alert.alert("요청 실패", message);
+				showSuccess("요청 완료", "근무 기록 정정 요청이 전송되었습니다.");
+			} catch {
+				showError("요청 실패", "요청에 실패했습니다. 다시 시도해주세요.");
 			}
 		},
 		[]
@@ -73,13 +69,9 @@ const useCorrectionRequest = () => {
 					...data,
 				});
 				setAddModalVisible(false);
-				Alert.alert("요청 완료", "근무 추가 요청이 전송되었습니다.");
-			} catch (error) {
-				const message =
-					error instanceof Error
-						? error.message
-						: "요청에 실패했습니다. 다시 시도해주세요.";
-				Alert.alert("요청 실패", message);
+				showSuccess("요청 완료", "근무 추가 요청이 전송되었습니다.");
+			} catch {
+				showError("요청 실패", "요청에 실패했습니다. 다시 시도해주세요.");
 			}
 		},
 		[]

--- a/src/hooks/worker/useGetCorrectionRequests.ts
+++ b/src/hooks/worker/useGetCorrectionRequests.ts
@@ -100,7 +100,7 @@ export function useGetCorrectionRequests(): UseGetCorrectionRequestsReturn {
     try {
       const response = await deleteCorrectionRequest(id);
       if (response.success) {
-        showSuccess("요청이 취소되었습니다.");
+        showSuccess("취소 완료", "요청이 취소되었습니다.");
         setExpandedId(null);
         setDetail(null);
         await fetchRequests();
@@ -109,7 +109,7 @@ export function useGetCorrectionRequests(): UseGetCorrectionRequestsReturn {
       }
     } catch (error) {
       console.warn("정정요청 취소 실패:", error);
-      showError("요청 취소에 실패했습니다.");
+      showError("취소 실패", "요청 취소에 실패했습니다.");
     } finally {
       setIsDeleting(false);
     }

--- a/src/hooks/worker/useGetCorrectionRequests.ts
+++ b/src/hooks/worker/useGetCorrectionRequests.ts
@@ -105,7 +105,7 @@ export function useGetCorrectionRequests(): UseGetCorrectionRequestsReturn {
         setDetail(null);
         await fetchRequests();
       } else {
-        showError(response.error?.message ?? "요청 취소에 실패했습니다.");
+        showError("취소 실패", "요청 취소에 실패했습니다.");
       }
     } catch (error) {
       console.warn("정정요청 취소 실패:", error);

--- a/src/hooks/worker/useProfileEdit.ts
+++ b/src/hooks/worker/useProfileEdit.ts
@@ -99,13 +99,7 @@ export function useProfileEdit({ user, onSuccess, onClose }: UseProfileEditParam
         onSuccess();
         onClose();
       } else {
-        // 서버 유효성 검증 실패
-        const fieldErrors = response.error?.fieldErrors;
-        if (fieldErrors && fieldErrors.length > 0) {
-          showError(fieldErrors[0].message);
-        } else {
-          showError(response.error?.message ?? "프로필 수정에 실패했습니다.");
-        }
+        showError("수정 실패", "프로필 수정에 실패했습니다.");
       }
     } catch (error) {
       console.error("프로필 수정 실패:", error);

--- a/src/hooks/worker/useProfileEdit.ts
+++ b/src/hooks/worker/useProfileEdit.ts
@@ -103,7 +103,7 @@ export function useProfileEdit({ user, onSuccess, onClose }: UseProfileEditParam
       }
     } catch (error) {
       console.error("프로필 수정 실패:", error);
-      showError("프로필 수정에 실패했습니다.");
+      showError("수정 실패", "프로필 수정에 실패했습니다.");
     } finally {
       setIsSubmitting(false);
     }

--- a/src/screens/auth/signup/Step4AlarmScreen.tsx
+++ b/src/screens/auth/signup/Step4AlarmScreen.tsx
@@ -70,7 +70,7 @@ const Step4AlarmScreen: React.FC = () => {
 
 			// 400 에러 (이미 가입된 계정 등)
 			if (loginError.status === 400) {
-				showError("회원가입 실패", loginError.message);
+				showError("회원가입 실패", "이미 가입된 계정입니다.");
 			} else {
 				// 그 외 에러
 				showError("회원가입 실패", "회원가입에 실패하였습니다.");

--- a/src/screens/auth/signup/Step4AlarmScreen.tsx
+++ b/src/screens/auth/signup/Step4AlarmScreen.tsx
@@ -73,7 +73,7 @@ const Step4AlarmScreen: React.FC = () => {
 				showError("회원가입 실패", "이미 가입된 계정입니다.");
 			} else {
 				// 그 외 에러
-				showError("회원가입 실패", "회원가입에 실패하였습니다.");
+				showError("회원가입 실패", "회원가입에 실패했습니다.");
 			}
 
 			// SignUp Store 초기화

--- a/src/screens/employer/EmployerRemittanceManageScreen.tsx
+++ b/src/screens/employer/EmployerRemittanceManageScreen.tsx
@@ -147,8 +147,8 @@ const EmployerRemittanceManageScreen: React.FC = () => {
     try {
       const res = await getSalaryById(salaryPaymentItem.id);
       setSalaryDetail(res.data ?? null);
-    } catch (e: any) {
-      Alert.alert("급여명세서 조회 실패", e.message ?? "다시 시도해주세요.");
+    } catch {
+      Alert.alert("급여명세서 조회 실패", "다시 시도해주세요.");
       setIsSalarySheetVisible(false);
     } finally {
       setIsSalaryDetailLoading(false);
@@ -200,8 +200,8 @@ const EmployerRemittanceManageScreen: React.FC = () => {
               } else {
                 Alert.alert("토스 앱 필요", "송금을 위해 토스 앱을 설치해주세요.");
               }
-            } catch (e: any) {
-              Alert.alert("송금 실패", e.message ?? "다시 시도해주세요.");
+            } catch {
+              Alert.alert("송금 실패", "다시 시도해주세요.");
             }
           },
         },
@@ -215,8 +215,8 @@ const EmployerRemittanceManageScreen: React.FC = () => {
       await completePayment(pendingPaymentId);
       setPendingPaymentId(null);
       setIsPaymentCompleted(true);
-    } catch (e: any) {
-      Alert.alert("완료 처리 실패", e.message ?? "다시 시도해주세요.");
+    } catch {
+      Alert.alert("완료 처리 실패", "다시 시도해주세요.");
     }
   };
 

--- a/src/screens/employer/EmployerRemittanceManageScreen.tsx
+++ b/src/screens/employer/EmployerRemittanceManageScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useEffect } from "react";
 import { StyleSheet, ScrollView, ActivityIndicator, View, TouchableOpacity, Linking, Alert } from "react-native";
+import { showError } from "../../utils/alert";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -148,7 +149,7 @@ const EmployerRemittanceManageScreen: React.FC = () => {
       const res = await getSalaryById(salaryPaymentItem.id);
       setSalaryDetail(res.data ?? null);
     } catch {
-      Alert.alert("급여명세서 조회 실패", "다시 시도해주세요.");
+      showError("급여명세서 조회 실패", "다시 시도해주세요.");
       setIsSalarySheetVisible(false);
     } finally {
       setIsSalaryDetailLoading(false);
@@ -201,7 +202,7 @@ const EmployerRemittanceManageScreen: React.FC = () => {
                 Alert.alert("토스 앱 필요", "송금을 위해 토스 앱을 설치해주세요.");
               }
             } catch {
-              Alert.alert("송금 실패", "다시 시도해주세요.");
+              showError("송금 실패", "다시 시도해주세요.");
             }
           },
         },
@@ -216,7 +217,7 @@ const EmployerRemittanceManageScreen: React.FC = () => {
       setPendingPaymentId(null);
       setIsPaymentCompleted(true);
     } catch {
-      Alert.alert("완료 처리 실패", "다시 시도해주세요.");
+      showError("완료 처리 실패", "다시 시도해주세요.");
     }
   };
 

--- a/src/screens/employer/EmployerWorkerManageScreen.tsx
+++ b/src/screens/employer/EmployerWorkerManageScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { StyleSheet, FlatList, ActivityIndicator, View, Alert } from "react-native";
+import { StyleSheet, FlatList, ActivityIndicator, View } from "react-native";
 import { Text } from "../../components/common/Text";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useNavigation } from "@react-navigation/native";
@@ -24,6 +24,7 @@ import type { ContractUpdateRequest } from "../../types/employer/employer.types"
 import type { WorkplaceDetails } from "../../api/employer/types";
 import { useWorkplaceManagement } from "../../hooks/employer/useWorkplaceManagement";
 import useWorkplaceContracts from "../../hooks/employer/useWorkplaceContracts";
+import { showSuccess, showError } from "../../utils/alert";
 
 
 const TAB_SCREEN_MAP: Record<EmployerTabName, keyof EmployerStackParamList> = {
@@ -87,9 +88,9 @@ const EmployerWorkerManageScreen: React.FC = () => {
     try {
       await updateWorker(contractId, data);
       setExpandedContractId(null);
-      Alert.alert("수정 완료", "근무자 정보가 수정되었습니다.");
+      showSuccess("수정 완료", "근무자 정보가 수정되었습니다.");
     } catch {
-      Alert.alert("수정 실패", "근무자 정보 수정 중 오류가 발생했습니다.");
+      showError("수정 실패", "근무자 정보 수정 중 오류가 발생했습니다.");
     }
   };
 
@@ -101,7 +102,7 @@ const EmployerWorkerManageScreen: React.FC = () => {
         setSelectedFilterId("all");
       }
     } catch {
-      Alert.alert("퇴사 처리 실패", "퇴사 처리 중 오류가 발생했습니다.");
+      showError("퇴사 처리 실패", "퇴사 처리 중 오류가 발생했습니다.");
     }
   };
 

--- a/src/screens/employer/mypage/EmployerWithdrawScreen.tsx
+++ b/src/screens/employer/mypage/EmployerWithdrawScreen.tsx
@@ -42,9 +42,8 @@ const EmployerWithdrawScreen: React.FC<Props> = ({ navigation }) => {
           },
         },
       ]);
-    } catch (error: any) {
-      const message = error?.message || "회원 탈퇴 중 오류가 발생했습니다.";
-      Alert.alert("탈퇴 실패", message, [{ text: "확인" }]);
+    } catch {
+      Alert.alert("탈퇴 실패", "회원 탈퇴 중 오류가 발생했습니다.", [{ text: "확인" }]);
     } finally {
       setLoading(false);
     }

--- a/src/screens/onboarding/WelcomeScreen.tsx
+++ b/src/screens/onboarding/WelcomeScreen.tsx
@@ -4,10 +4,10 @@ import {
 	StyleSheet,
 	TouchableOpacity,
 	View,
-	Alert,
 	ActivityIndicator,
 } from "react-native";
 import { Text } from "../../components/common/Text";
+import { showError } from "../../utils/alert";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { login } from "@react-native-seoul/kakao-login";
 import { kakaoLoginWithToken, devLogin } from "../../api/auth";
@@ -36,10 +36,7 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
 			kakaoAccessToken = token?.accessToken;
 
 			if (!kakaoAccessToken) {
-				Alert.alert(
-					"로그인 실패",
-					"카카오 액세스 토큰을 가져오지 못했습니다."
-				);
+				showError("로그인 실패", "카카오 로그인에 실패했습니다. 다시 시도해주세요.");
 				return;
 			}
 
@@ -76,9 +73,7 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
 			}
 
 			// 그 외 에러
-			const message =
-				loginError.message || "로그인에 실패했습니다. 다시 시도해주세요.";
-			Alert.alert("로그인 실패", message);
+			showError("로그인 실패", "로그인에 실패했습니다. 다시 시도해주세요.");
 		} finally {
 			setIsLoading(false);
 		}
@@ -97,9 +92,8 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
 				});
 				onLoginSuccess?.(result.data.userType);
 			}
-		} catch (error: any) {
-			console.error("Dev 로그인 에러:", error);
-			Alert.alert("Dev 로그인 실패", error?.message || "서버 연결을 확인해주세요.");
+		} catch {
+			showError("Dev 로그인 실패", "서버 연결을 확인해주세요.");
 		} finally {
 			setIsLoading(false);
 		}

--- a/src/screens/worker/mypage/WorkerWithdrawScreen.tsx
+++ b/src/screens/worker/mypage/WorkerWithdrawScreen.tsx
@@ -52,9 +52,8 @@ const WithdrawScreen: React.FC<Props> = ({ navigation }) => {
 					},
 				},
 			]);
-		} catch (error: any) {
-			const message = error?.message || "회원 탈퇴 중 오류가 발생했습니다.";
-			Alert.alert("탈퇴 실패", message, [{ text: "확인" }]);
+		} catch {
+			Alert.alert("탈퇴 실패", "회원 탈퇴 중 오류가 발생했습니다.", [{ text: "확인" }]);
 		} finally {
 			setLoading(false);
 		}


### PR DESCRIPTION
## 📌 Issue number and Link

closed #28

## ✏️ Summary

앱 전체의 Alert/Toast 에러 메시지를 표준화합니다.

기존에는 동일한 동작에 대한 피드백을 `Alert.alert()`과 `showError()` Toast가 혼재되어 사용되었고, 유효성 검증 타이틀도 `"알림"`, `"입력 오류"`, `"검색어 입력"` 등으로 제각각이었습니다. 또한 서버의 `error.message`가 그대로 사용자에게 노출되는 문제가 있었습니다.

이번 PR에서는 아래 기준을 적용해 전체를 정리합니다.

| 유형 | 방식 | 기준 |
|------|------|------|
| 단순 결과 피드백 (성공/실패) | Toast (`showSuccess`, `showError`) | 사용자 확인 불필요 |
| 사용자 확인/선택 필요 | `Alert.alert()` 유지 | 로그아웃, 삭제, 승인/거절, 회원탈퇴 등 |
| 유효성 검증 타이틀 | `"입력 확인"` 통일 | — |
| 서버/기술적 에러 메시지 | 고정 한국어 문자열로 대체 | `error.message` 직접 노출 제거 |

## 📝 Changes

**Phase 1 — 단순 피드백 Alert → Toast 변환 (12개 파일)**

- `useCorrectionRequest.ts`: 근무 추가/정정 요청 성공·실패 피드백 → `showSuccess`/`showError`
- `useLogoutHandler.ts`: 로그아웃 성공·실패 피드백 → `showSuccess`/`showError` (확인 다이얼로그는 유지)
- `EmployerWorkerManageScreen.tsx`: 근무자 정보 수정·퇴사 처리 성공·실패 → `showSuccess`/`showError`
- `EmployerEditWorkModal.tsx`: 근무 수정 성공·실패 → `showSuccess`/`showError`, `isAxiosError` 제거
- `EmployerWorkerListSection.tsx`: 퇴사 처리 실패 → `showError`, `isAxiosError` 제거
- `AddWorkerModal.tsx`: 근무자 추가 성공·실패 → `showSuccess`/`showError`, 오탈자 수정 ("추가가 실패하였습니다" → "추가에 실패했습니다")
- `AddWorkplaceModal.tsx`: 주소 검색 결과 없음·실패, 근무지 등록 성공·실패 → Toast
- `EmployerAddWorkModal.tsx`: 근무 추가 실패 → `showError`, `isAxiosError` 제거
- `useWorkplaceManagement.ts`: 근무지 추가·삭제·수정 실패 → `showError`, 확인 다이얼로그 유지

**Phase 2 — 유효성 검증 타이틀 `"입력 확인"` 통일 (5개 파일)**

- `AddWorkplaceModal.tsx`: `"검색어 입력"` → `"입력 확인"`
- `EmployerAddWorkModal.tsx`: `"알림"` → `"입력 확인"`
- `useWorkplaceManagement.ts`: `"입력 오류"` 4건 → `"입력 확인"`
- `useAddWorker.ts`: `"입력 오류"` → `"입력 확인"`
- `WorkerCard.tsx`: `"입력 오류"` 2건 → `"입력 확인"`

**Phase 3 — 배포 환경 대응: 서버/기술적 메시지 노출 제거 (8개 파일)**

- `WelcomeScreen.tsx`: `"카카오 액세스 토큰을 가져오지 못했습니다."` 등 기술적 메시지 제거, `loginError.message` 직접 노출 제거, `Alert` import 제거
- `Step4AlarmScreen.tsx`: 400 에러 시 `loginError.message` 노출 제거 → `"이미 가입된 계정입니다."` 고정, 문법 교정 (`"실패하였습니다"` → `"실패했습니다"`)
- `useAccountEdit.ts`: `fieldErrors[0].message`, `response.error?.message` → 고정 문자열
- `useProfileEdit.ts`: `fieldErrors[0].message`, `response.error?.message` → 고정 문자열
- `useGetCorrectionRequests.ts`: `response.error?.message` → 고정 문자열
- `useReceivedRequests.ts`: 승인·거절 `response.error?.message` → 고정 문자열
- `useAddWorker.ts`: 검색 실패 `Alert.alert` 2건 → `showError` Toast
- `EmployerWithdrawScreen.tsx`, `WorkerWithdrawScreen.tsx`: `error?.message` 노출 제거 (탈퇴 확인·완료 다이얼로그는 유지)
- `EmployerRemittanceManageScreen.tsx`: `e.message` 노출 3건 제거 (급여명세서 조회·송금·완료 처리 실패)

## 🔎 PR Type

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [x] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot

해당 없음 (UI 변경 없음 — 메시지 내용/표시 방식만 변경)