### PR TITLE
[Feat] 백엔드 API 변경사항에 따른 모바일 앱 API 경로 동기화

### DIFF
--- a/src/api/settings/index.ts
+++ b/src/api/settings/index.ts
@@ -17,7 +17,7 @@ export const getNotificationSettings = async (): Promise<ApiResponse<Notificatio
   } catch (error) {
     const axiosError = error as AxiosError<ApiResponse<NotificationSettings>>;
     const message = axiosError.response?.data?.error?.message ?? "알림 설정 조회에 실패했습니다.";
-    return { success: false, data: null as any, error: { code: "ERROR", message, fieldErrors: [] } };
+    return { success: false, error: { code: "ERROR", message, fieldErrors: [] } };
   }
 };
 
@@ -34,6 +34,6 @@ export const updateNotificationSettings = async (
   } catch (error) {
     const axiosError = error as AxiosError<ApiResponse<NotificationSettings>>;
     const message = axiosError.response?.data?.error?.message ?? "알림 설정 수정에 실패했습니다.";
-    return { success: false, data: null as any, error: { code: "ERROR", message, fieldErrors: [] } };
+    return { success: false, error: { code: "ERROR", message, fieldErrors: [] } };
   }
 };

--- a/src/api/settings/index.ts
+++ b/src/api/settings/index.ts
@@ -1,0 +1,39 @@
+import { AxiosError } from "axios";
+import api from "../axios";
+import type { ApiResponse } from "../../types/api.types";
+import type {
+  NotificationSettings,
+  NotificationSettingsUpdateRequest,
+} from "./types";
+
+/**
+ * 내 알림 설정 조회
+ * GET /api/settings/me
+ */
+export const getNotificationSettings = async (): Promise<ApiResponse<NotificationSettings>> => {
+  try {
+    const { data } = await api.get<ApiResponse<NotificationSettings>>("/api/settings/me");
+    return data;
+  } catch (error) {
+    const axiosError = error as AxiosError<ApiResponse<NotificationSettings>>;
+    const message = axiosError.response?.data?.error?.message ?? "알림 설정 조회에 실패했습니다.";
+    return { success: false, data: null as any, error: { code: "ERROR", message, fieldErrors: [] } };
+  }
+};
+
+/**
+ * 내 알림 설정 수정
+ * PUT /api/settings/me
+ */
+export const updateNotificationSettings = async (
+  reqData: NotificationSettingsUpdateRequest
+): Promise<ApiResponse<NotificationSettings>> => {
+  try {
+    const { data } = await api.put<ApiResponse<NotificationSettings>>("/api/settings/me", reqData);
+    return data;
+  } catch (error) {
+    const axiosError = error as AxiosError<ApiResponse<NotificationSettings>>;
+    const message = axiosError.response?.data?.error?.message ?? "알림 설정 수정에 실패했습니다.";
+    return { success: false, data: null as any, error: { code: "ERROR", message, fieldErrors: [] } };
+  }
+};

--- a/src/api/settings/types.ts
+++ b/src/api/settings/types.ts
@@ -1,0 +1,29 @@
+// ============ 알림 설정 관련 타입 ============
+
+/** [GET/PUT] /api/settings/me 응답 데이터 */
+export interface NotificationSettings {
+  id: number;
+  userId: number;
+  notificationEnabled: boolean;
+  pushEnabled: boolean;
+  emailEnabled: boolean;
+  smsEnabled: boolean;
+  scheduleChangeAlertEnabled: boolean;
+  paymentAlertEnabled: boolean;
+  correctionRequestAlertEnabled: boolean;
+  invitationAlertEnabled: boolean;
+  resignationAlertEnabled: boolean;
+}
+
+/** [PUT] /api/settings/me 요청 데이터 */
+export interface NotificationSettingsUpdateRequest {
+  notificationEnabled?: boolean;
+  pushEnabled?: boolean;
+  emailEnabled?: boolean;
+  smsEnabled?: boolean;
+  scheduleChangeAlertEnabled?: boolean;
+  paymentAlertEnabled?: boolean;
+  correctionRequestAlertEnabled?: boolean;
+  invitationAlertEnabled?: boolean;
+  resignationAlertEnabled?: boolean;
+}

--- a/src/api/user/types.ts
+++ b/src/api/user/types.ts
@@ -25,7 +25,7 @@ export interface UserUpdateRequest {
 
 // ============ 근로자 정보 관련 타입 ============
 
-/** [GET] /api/workers/user/{userId}, [PUT] /api/users/me/account 응답 데이터 */
+/** [GET] /api/users/me, [PUT] /api/users/me/account 응답 데이터 */
 export interface WorkerResponse {
   id: number;
   userId: number;

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -1,2 +1,1 @@
-export const PUSH_ENABLED_KEY = "push_notification_enabled";
 export const PUSH_TOKEN_KEY = "fcm_push_token";

--- a/src/hooks/common/useFcmToken.ts
+++ b/src/hooks/common/useFcmToken.ts
@@ -1,12 +1,11 @@
 /**
  * FCM 푸시 토큰 자동 등록 훅.
- * 로그인 상태이고 사용자가 푸시 알림을 허용한 경우에만 토큰을 등록한다.
+ * 로그인 상태이고 서버 알림 설정에서 pushEnabled가 true인 경우에만 토큰을 등록한다.
  */
 import { useEffect } from "react";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useAuthStore } from "../../stores/authStore";
 import { registerPushToken } from "../../utils/pushToken";
-import { PUSH_ENABLED_KEY } from "../../constants/storageKeys";
+import { getNotificationSettings } from "../../api/settings";
 
 export function useFcmToken() {
 	const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
@@ -14,9 +13,10 @@ export function useFcmToken() {
 	useEffect(() => {
 		if (!isLoggedIn) return;
 
-		AsyncStorage.getItem(PUSH_ENABLED_KEY).then((value) => {
-			// 기본값은 허용 (null이면 아직 설정한 적 없음 → 허용)
-			if (value !== "false") {
+		getNotificationSettings().then((res) => {
+			// 서버 설정 조회 실패 시 기본값으로 허용 처리
+			const pushEnabled = res.success && res.data ? res.data.pushEnabled : true;
+			if (pushEnabled) {
 				registerPushToken();
 			}
 		});

--- a/src/hooks/employer/useReceivedRequests.ts
+++ b/src/hooks/employer/useReceivedRequests.ts
@@ -171,11 +171,32 @@ export function useReceivedRequests(): UseReceivedRequestsReturn {
 				setDetail(response.data);
 			}
 		} catch {
-			console.warn("정정요청 상세 조회 실패");
+			// 상세 조회 실패 시 목록 아이템 데이터로 대체 (백엔드 버그 임시 대응)
+			const listItem = allRequests.find((r) => r.id === id);
+			if (listItem) {
+				setDetail({
+					id: listItem.id,
+					type: listItem.type,
+					workRecordId: listItem.workRecordId,
+					contractId: 0,
+					originalWorkDate: null,
+					originalStartTime: listItem.originalStartTime,
+					originalEndTime: listItem.originalEndTime,
+					requestedWorkDate: listItem.workDate,
+					requestedStartTime: listItem.requestedStartTime,
+					requestedEndTime: listItem.requestedEndTime,
+					requestedBreakMinutes: 0,
+					requestedMemo: "",
+					status: listItem.status,
+					requester: listItem.requester,
+					reviewedAt: null,
+					createdAt: listItem.createdAt,
+				});
+			}
 		} finally {
 			setIsDetailLoading(false);
 		}
-	}, [expandedId]);
+	}, [expandedId, allRequests]);
 
 	// 승인
 	const handleApprove = useCallback((id: number) => {

--- a/src/hooks/employer/useReceivedRequests.ts
+++ b/src/hooks/employer/useReceivedRequests.ts
@@ -171,6 +171,7 @@ export function useReceivedRequests(): UseReceivedRequestsReturn {
 				setDetail(response.data);
 			}
 		} catch {
+			// TODO: 백엔드 CREATE 타입 500 에러 수정 후 이 폴백 로직 제거
 			// 상세 조회 실패 시 목록 아이템 데이터로 대체 (백엔드 버그 임시 대응)
 			const listItem = allRequests.find((r) => r.id === id);
 			if (listItem) {

--- a/src/screens/common/NotificationSettingsScreen.tsx
+++ b/src/screens/common/NotificationSettingsScreen.tsx
@@ -7,27 +7,29 @@ import {
 	StyleSheet,
 	Linking,
 	Platform,
+	ActivityIndicator,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { useNavigation } from "@react-navigation/native";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Notifications from "expo-notifications";
 import { Text } from "../../components/common/Text";
 import { registerPushToken, unregisterPushToken } from "../../utils/pushToken";
+import { getNotificationSettings, updateNotificationSettings } from "../../api/settings";
 import { colors } from "../../constants/colors";
-import { PUSH_ENABLED_KEY } from "../../constants/storageKeys";
 
 const NotificationSettingsScreen = () => {
 	const navigation = useNavigation();
 	const [pushEnabled, setPushEnabled] = useState(true);
+	const [isLoading, setIsLoading] = useState(true);
 	const [isToggling, setIsToggling] = useState(false);
 
 	useEffect(() => {
-		AsyncStorage.getItem(PUSH_ENABLED_KEY).then((value) => {
-			if (value !== null) {
-				setPushEnabled(value === "true");
+		getNotificationSettings().then((res) => {
+			if (res.success && res.data) {
+				setPushEnabled(res.data.pushEnabled);
 			}
+			setIsLoading(false);
 		});
 	}, []);
 
@@ -68,8 +70,8 @@ const NotificationSettingsScreen = () => {
 			} else {
 				await unregisterPushToken();
 			}
+			await updateNotificationSettings({ pushEnabled: newValue });
 			setPushEnabled(newValue);
-			await AsyncStorage.setItem(PUSH_ENABLED_KEY, String(newValue));
 		} catch {
 			// silent fail
 		} finally {
@@ -101,44 +103,50 @@ const NotificationSettingsScreen = () => {
 				<View style={{ width: 28 }} />
 			</View>
 
-			<View style={styles.content}>
-				<View style={styles.settingRow}>
-					<View style={styles.settingInfo}>
-						<Text weight="SemiBold" style={styles.settingTitle}>
-							푸시 알림
-						</Text>
-						<Text style={styles.settingDesc}>
-							앱을 사용하지 않을 때도 알림을 받습니다.
-						</Text>
-					</View>
-					<Switch
-						value={pushEnabled}
-						onValueChange={handleToggle}
-						disabled={isToggling}
-						trackColor={{
-							false: colors.disabled,
-							true: colors.primary,
-						}}
-						thumbColor={colors.white}
-					/>
+			{isLoading ? (
+				<View style={styles.loadingContainer}>
+					<ActivityIndicator color={colors.primary} />
 				</View>
+			) : (
+				<View style={styles.content}>
+					<View style={styles.settingRow}>
+						<View style={styles.settingInfo}>
+							<Text weight="SemiBold" style={styles.settingTitle}>
+								푸시 알림
+							</Text>
+							<Text style={styles.settingDesc}>
+								앱을 사용하지 않을 때도 알림을 받습니다.
+							</Text>
+						</View>
+						<Switch
+							value={pushEnabled}
+							onValueChange={handleToggle}
+							disabled={isToggling}
+							trackColor={{
+								false: colors.disabled,
+								true: colors.primary,
+							}}
+							thumbColor={colors.white}
+						/>
+					</View>
 
-				<Pressable style={styles.linkRow} onPress={openDeviceSettings}>
-					<Text weight="Medium" style={styles.linkText}>
-						디바이스 알림 설정 열기
+					<Pressable style={styles.linkRow} onPress={openDeviceSettings}>
+						<Text weight="Medium" style={styles.linkText}>
+							디바이스 알림 설정 열기
+						</Text>
+						<Ionicons
+							name="open-outline"
+							size={18}
+							color={colors.textSecondary}
+						/>
+					</Pressable>
+
+					<Text style={styles.hintText}>
+						디바이스 설정에서 알림 권한을 끄면 푸시 알림이{"\n"}
+						앱 내 설정과 관계없이 수신되지 않습니다.
 					</Text>
-					<Ionicons
-						name="open-outline"
-						size={18}
-						color={colors.textSecondary}
-					/>
-				</Pressable>
-
-				<Text style={styles.hintText}>
-					디바이스 설정에서 알림 권한을 끄면 푸시 알림이{"\n"}
-					앱 내 설정과 관계없이 수신되지 않습니다.
-				</Text>
-			</View>
+				</View>
+			)}
 		</SafeAreaView>
 	);
 };
@@ -160,6 +168,11 @@ const styles = StyleSheet.create({
 	headerTitle: {
 		fontSize: 18,
 		color: colors.textPrimary,
+	},
+	loadingContainer: {
+		flex: 1,
+		justifyContent: "center",
+		alignItems: "center",
 	},
 	content: {
 		paddingHorizontal: 20,

--- a/src/screens/common/NotificationSettingsScreen.tsx
+++ b/src/screens/common/NotificationSettingsScreen.tsx
@@ -16,6 +16,7 @@ import * as Notifications from "expo-notifications";
 import { Text } from "../../components/common/Text";
 import { registerPushToken, unregisterPushToken } from "../../utils/pushToken";
 import { getNotificationSettings, updateNotificationSettings } from "../../api/settings";
+import { showError } from "../../utils/alert";
 import { colors } from "../../constants/colors";
 
 const NotificationSettingsScreen = () => {
@@ -70,7 +71,14 @@ const NotificationSettingsScreen = () => {
 			} else {
 				await unregisterPushToken();
 			}
-			await updateNotificationSettings({ pushEnabled: newValue });
+			const res = await updateNotificationSettings({ pushEnabled: newValue });
+			if (!res.success) {
+				// 서버 설정 업데이트 실패 시 FCM 토큰 롤백
+				if (newValue) await unregisterPushToken();
+				else await registerPushToken();
+				showError("오류", "알림 설정 변경에 실패했습니다. 잠시 후 다시 시도해주세요.");
+				return;
+			}
 			setPushEnabled(newValue);
 		} catch {
 			// silent fail


### PR DESCRIPTION
## 📌 Issue number and Link

closed #31

## ✏️ Summary

백엔드 API 업데이트에 따라 모바일 앱의 API 연동을 동기화합니다.
- 구 API 경로 참조 주석 수정
- 알림 설정 API 신규 연동 (로컬 저장 → 서버 동기화)
- 고용주 정정요청 상세 조회 실패 임시 대응

## 📝 Changes

**[Chore] JSDoc 주석 수정**
- `WorkerResponse`의 JSDoc에 남아있던 구 경로 `/api/workers/user/{userId}` → `/api/users/me`로 수정

**[Feat] 알림 설정 API 연동 (`GET/PUT /api/settings/me`)**
- `src/api/settings/` 폴더 신규 생성 (`index.ts`, `types.ts`)
- `NotificationSettingsScreen`: AsyncStorage 로컬 저장 방식 → 서버 API 동기화 방식으로 교체
  - 화면 진입 시 `GET /api/settings/me`로 설정값 로드
  - 토글 변경 시 `PUT /api/settings/me`로 서버에 저장
- `useFcmToken`: 로그인 시 AsyncStorage 대신 서버 설정(`pushEnabled`)을 읽어 FCM 토큰 등록 여부 결정
- `storageKeys.ts`: 더 이상 사용하지 않는 `PUSH_ENABLED_KEY` 상수 제거

**[Fix] 정정요청 상세 조회 폴백 처리**
- `GET /api/employer/correction-requests/{id}`가 "CREATE" 타입 요청 ID에 대해서만 500 에러 반환하는 백엔드 버그 발견
- 임시 대응: 상세 조회 실패 시 이미 로드된 목록 데이터(`allRequests`)에서 해당 ID를 찾아 `CorrectionRequestDetail` 형태로 변환하여 표시
- 이에 따른 승인/거절(`PUT .../approve|reject`)의 500 에러는 백엔드 수정 필요 (프론트 대응 불가)

## 🔎 PR Type

- [x] Feature
- [x] Bugfix