### PR TITLE
[Fix] 근무지 주소 검색 결과 overflow로 인한 UI 깨짐 수정

### DIFF
--- a/src/components/employer/mypage/AddWorkplaceModal.tsx
+++ b/src/components/employer/mypage/AddWorkplaceModal.tsx
@@ -177,7 +177,7 @@ const AddWorkplaceModal: React.FC<AddWorkplaceModalProps> = ({
 					{/* 검색 결과 목록 */}
 					{showResults && searchResults.length > 0 && (
 						<View style={styles.resultList}>
-							 <ScrollView
+							<ScrollView
 								nestedScrollEnabled
 								keyboardShouldPersistTaps="handled"
 								showsVerticalScrollIndicator={false}
@@ -195,7 +195,7 @@ const AddWorkplaceModal: React.FC<AddWorkplaceModalProps> = ({
 									<Text style={styles.resultZoneNo}>{item.zoneNo}</Text>
 									<Text style={styles.resultAddress}>{item.addressName}</Text>
 								</TouchableOpacity>
-							))}	
+								))}	
 							</ScrollView>
 						</View>
 					)}

--- a/src/components/employer/mypage/AddWorkplaceModal.tsx
+++ b/src/components/employer/mypage/AddWorkplaceModal.tsx
@@ -177,7 +177,12 @@ const AddWorkplaceModal: React.FC<AddWorkplaceModalProps> = ({
 					{/* 검색 결과 목록 */}
 					{showResults && searchResults.length > 0 && (
 						<View style={styles.resultList}>
-							{searchResults.map((item, index) => (
+							 <ScrollView
+								nestedScrollEnabled
+								keyboardShouldPersistTaps="handled"
+								showsVerticalScrollIndicator={false}
+							>
+							    {searchResults.map((item, index) => (
 								<TouchableOpacity
 									key={`${item.zoneNo}-${index}`}
 									style={[
@@ -190,7 +195,8 @@ const AddWorkplaceModal: React.FC<AddWorkplaceModalProps> = ({
 									<Text style={styles.resultZoneNo}>{item.zoneNo}</Text>
 									<Text style={styles.resultAddress}>{item.addressName}</Text>
 								</TouchableOpacity>
-							))}
+							))}	
+							</ScrollView>
 						</View>
 					)}
 
@@ -321,7 +327,7 @@ const styles = StyleSheet.create({
 		maxHeight: 200,
 	},
 	resultItem: {
-		paddingVertical: 12,
+		paddingVertical: 8,
 		paddingHorizontal: 14,
 	},
 	resultItemBorder: {


### PR DESCRIPTION
## 📌 Issue number and Link
closed #42

## ✏️ Summary
근무지 추가 모달에서 주소 검색 결과가 여러 개일 때, 결과 목록이 아래 폼 필드에 겹쳐지는 UI 버그 수정

## 📝 Changes
- `resultList` View를 `ScrollView`(nestedScrollEnabled)로 감싸 maxHeight(200px) 안에서 결과 목록 스크롤 가능하도록 수정
- `overflow: 'hidden'` 제거 (ScrollView가 maxHeight 경계 처리)

**원인**: React Native의 기본 overflow가 `visible`이라 `maxHeight`를 초과한 결과 항목들이 아래 폼 필드에 그대로 렌더링되었음

## 🔎 PR Type
- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
<img width="663" height="1440" alt="image" src="https://github.com/user-attachments/assets/e88979e0-809a-4865-a9af-e3fd29471401" />
