### PR TITLE
[Fix] 액세스 토큰 갱신 실패 버그 수정 (#39)

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -110,11 +110,21 @@ api.interceptors.response.use(
 			isRefreshing = true;
 
 			try {
+				// React Native는 withCredentials로 쿠키가 자동 전송되지 않아
+				// CookieManager로 쿠키를 직접 읽어 Cookie 헤더에 수동 첨부
+				const cookies = await CookieManager.get(API_BASE_URL);
+				const cookieHeader = Object.entries(cookies)
+					.map(([key, cookie]) => `${key}=${cookie.value}`)
+					.join("; ");
+
 				// Refresh Token(쿠키)으로 새 Access Token 요청
 				const response = await axios.post<ApiResponse<AuthSuccessData>>(
 					`${API_BASE_URL}/api/auth/refresh`,
 					{},
-					{ withCredentials: true }
+					{
+						withCredentials: true,
+						headers: cookieHeader ? { Cookie: cookieHeader } : undefined,
+					}
 				);
 
 				const newAccessToken = response.data.data?.accessToken;

--- a/src/hooks/common/useLogoutHandler.ts
+++ b/src/hooks/common/useLogoutHandler.ts
@@ -1,7 +1,7 @@
 import { Alert } from "react-native";
 import { logout } from "../../api/auth";
 import { unregisterPushToken } from "../../utils/pushToken";
-import { showSuccess, showError } from "../../utils/alert";
+import { showSuccess } from "../../utils/alert";
 
 /**
  * 로그아웃 핸들러
@@ -28,7 +28,7 @@ export const useLogoutHandler = (
               await logout();
               showSuccess("로그아웃 완료", "로그아웃이 완료되었습니다.");
             } catch {
-              showError("로그아웃 실패", "로그아웃 처리 중 오류가 발생했습니다.");
+              // 로그아웃 API 실패는 무시 (finally에서 화면 이동 보장)
             } finally {
               navigation.getParent()?.reset({ index: 0, routes: [{ name: "Welcome" }] });
             }

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,10 +1,11 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { NavigationContainer, NavigationContainerRef } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useOnboardingStatus } from "../hooks/common/useOnboardingStatus";
 import { useNotificationStream } from "../hooks/common/useNotificationStream";
 import { useFcmToken } from "../hooks/common/useFcmToken";
 import { useNotificationNavigation } from "../hooks/common/useNotificationNavigation";
+import { setLogoutCallback } from "../api/axios";
 import OnboardingStack from "./OnboardingStack";
 import WelcomeScreen from "../screens/onboarding/WelcomeScreen";
 import SignUpNavigator from "./SignUpNavigator";
@@ -28,6 +29,13 @@ const RootNavigator = () => {
 	useNotificationStream();
 	useFcmToken();
 	useNotificationNavigation(isNavReady ? navigationRef.current : null);
+
+	useEffect(() => {
+		if (!isNavReady) return;
+		setLogoutCallback(() => {
+			navigationRef.current?.reset({ index: 0, routes: [{ name: "Welcome" }] });
+		});
+	}, [isNavReady]);
 
 	if (isLoading) {
 		return null;


### PR DESCRIPTION
## 📌 Issue number and Link

closed #39

## ✏️ Summary

React Native 환경에서 액세스 토큰 만료(15분) 후 토큰 갱신이 실패하여 빈 UI가 노출되고 "로그아웃 실패" 에러가 뜨던 버그를 수정합니다.

## 📝 Changes

### 원인

| # | 원인 | 증상 |
|---|------|------|
| 1 | `withCredentials: true`만으로는 React Native에서 쿠키가 자동 전송되지 않음 | 리프레시 요청 자체 실패 |
| 2 | `setLogoutCallback` 미등록 | 갱신 실패 후 빈 화면에 갇힘 |
| 3 | 로그아웃 시 인증 상태 초기화 후 API 재호출 | "로그아웃 실패" 에러 Toast 노출 |

### 수정 사항

**`src/navigation/RootNavigator.tsx`**
- 네비게이션 준비 완료(`isNavReady`) 후 `setLogoutCallback` 등록
- 토큰 갱신 실패 시 Welcome 화면으로 자동 이동 보장

**`src/hooks/common/useLogoutHandler.ts`**
- 로그아웃 API 실패 시 불필요한 에러 Toast 제거
- `finally`에서 화면 이동이 보장되므로 에러 표시 불필요

**`src/api/axios.ts`**
- 리프레시 요청 시 `CookieManager.get()`으로 쿠키를 직접 읽어 `Cookie` 헤더에 수동 첨부
- React Native의 쿠키 자동 전송 미지원 문제 해결

## 🔎 PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot

> 15분 경과 후 토큰 갱신 정상 동작 확인 (실기기 테스트 완료)