### PR TITLE
[Feat] 근무지 관리 화면에 근무지 삭제 기능 추가 (#44)

### DIFF
--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -102,7 +102,7 @@ export const devLogin = async (
  */
 export const deleteMyAccount = async () => {
 	try {
-		const { data } = await api.delete("/api/users/me");
+		const { data } = await api.delete("/api/auth/withdraw");
 		return data;
 	} catch (error) {
 		const axiosError = error as AxiosError;

--- a/src/components/employer/mypage/EmployerWorkplaceCard.tsx
+++ b/src/components/employer/mypage/EmployerWorkplaceCard.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, TouchableOpacity } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import { Text } from "../../common/Text";
 import { colors } from "../../../constants/colors";
 
@@ -9,6 +10,7 @@ export interface EmployerWorkplaceCardProps {
 	colorCode?: string;
 	businessNumber?: string;
 	address?: string;
+	onDelete?: () => void;
 }
 
 const EmployerWorkplaceCard: React.FC<EmployerWorkplaceCardProps> = ({
@@ -17,16 +19,24 @@ const EmployerWorkplaceCard: React.FC<EmployerWorkplaceCardProps> = ({
 	colorCode,
 	businessNumber,
 	address,
+	onDelete,
 }) => {
 	return (
 		<View style={styles.card}>
 			<View style={styles.header}>
-				{colorCode && (
-					<View style={[styles.colorDot, { backgroundColor: colorCode }]} />
+				<View style={styles.nameRow}>
+					{colorCode && (
+						<View style={[styles.colorDot, { backgroundColor: colorCode }]} />
+					)}
+					<Text weight="Bold" style={styles.name}>
+						{name}
+					</Text>
+				</View>
+				{onDelete && (
+					<TouchableOpacity onPress={onDelete} hitSlop={8}>
+						<Ionicons name="trash-outline" size={20} color={colors.deleteRed} />
+					</TouchableOpacity>
 				)}
-				<Text weight="Bold" style={styles.name}>
-					{name}
-				</Text>
 			</View>
 			<Text style={styles.info}>직원 수: {workerCount}명</Text>
 			<Text style={styles.info}>사업자번호: {businessNumber ?? "?"}</Text>
@@ -51,7 +61,12 @@ const styles = StyleSheet.create({
 	header: {
 		flexDirection: "row",
 		alignItems: "center",
+		justifyContent: "space-between",
 		marginBottom: 10,
+	},
+	nameRow: {
+		flexDirection: "row",
+		alignItems: "center",
 	},
 	colorDot: {
 		width: 12,

--- a/src/hooks/employer/useWorkplaceManagement.ts
+++ b/src/hooks/employer/useWorkplaceManagement.ts
@@ -1,93 +1,32 @@
 import { useState, useEffect } from "react";
-import { Alert } from "react-native";
-import { showError } from "../../utils/alert";
 import type { WorkplaceDetails } from "../../api/employer/types";
-import {
-  getWorkplaces,
-  createWorkplace,
-  updateWorkplace,
-  deleteWorkplace,
-} from "../../api/employer/index";
-
-interface UseWorkplaceManagementProps {
-  onWorkplaceDeleted?: (workplaceId: number) => void;
-  onWorkplaceChanged?: (workplaceId: number) => void;
-}
+import { getWorkplaces } from "../../api/employer/index";
 
 interface UseWorkplaceManagementReturn {
-  // 상태
   workplaces: WorkplaceDetails[];
   isLoading: boolean;
   selectedWorkplaceId: number | null;
-  isAddingWorkplace: boolean;
-  isManagingWorkplaces: boolean;
-  selectedWorkplaceForEdit: number | null;
-  editingWorkplace: WorkplaceDetails | null;
-  newWorkplaceName: string;
-  newWorkplaceAddress: string;
-  newWorkplaceBusinessNumber: string;
-  newWorkplaceIsSmallBusiness: boolean;
-
-  // Setters
-  setWorkplaces: React.Dispatch<React.SetStateAction<WorkplaceDetails[]>>;
   setSelectedWorkplaceId: React.Dispatch<React.SetStateAction<number | null>>;
-  setIsAddingWorkplace: React.Dispatch<React.SetStateAction<boolean>>;
-  setIsManagingWorkplaces: React.Dispatch<React.SetStateAction<boolean>>;
-  setSelectedWorkplaceForEdit: React.Dispatch<React.SetStateAction<number | null>>;
-  setEditingWorkplace: React.Dispatch<React.SetStateAction<WorkplaceDetails | null>>;
-  setNewWorkplaceName: React.Dispatch<React.SetStateAction<string>>;
-  setNewWorkplaceAddress: React.Dispatch<React.SetStateAction<string>>;
-  setNewWorkplaceBusinessNumber: React.Dispatch<React.SetStateAction<string>>;
-  setNewWorkplaceIsSmallBusiness: React.Dispatch<React.SetStateAction<boolean>>;
-
-  // 핸들러 함수
-  handleManageWorkplaces: () => void;
-  handleCancelManageWorkplaces: () => void;
-  handleAddWorkplaceFromManage: () => void;
-  handleAddWorkplace: () => Promise<void>;
-  handleCancelAddWorkplace: () => void;
-  handleDeleteWorkplace: () => void;
-  handleEditWorkplace: (workplace: WorkplaceDetails) => void;
-  handleSaveWorkplaceEdit: () => Promise<void>;
-  handleCancelWorkplaceEdit: () => void;
-  handleEditingWorkplaceChange: (data: {
-    name?: string;
-    address?: string;
-    businessNumber?: string;
-    isSmallBusiness?: boolean;
-  }) => void;
 }
 
-export function useWorkplaceManagement({
-  onWorkplaceDeleted,
-  onWorkplaceChanged,
-}: UseWorkplaceManagementProps = {}): UseWorkplaceManagementReturn {
+export function useWorkplaceManagement(): UseWorkplaceManagementReturn {
   const [workplaces, setWorkplaces] = useState<WorkplaceDetails[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [selectedWorkplaceId, setSelectedWorkplaceId] = useState<number | null>(null);
-  const [isAddingWorkplace, setIsAddingWorkplace] = useState(false);
-  const [newWorkplaceName, setNewWorkplaceName] = useState("");
-  const [newWorkplaceAddress, setNewWorkplaceAddress] = useState("");
-  const [newWorkplaceBusinessNumber, setNewWorkplaceBusinessNumber] = useState("");
-  const [newWorkplaceIsSmallBusiness, setNewWorkplaceIsSmallBusiness] = useState(false);
-  const [isManagingWorkplaces, setIsManagingWorkplaces] = useState(false);
-  const [selectedWorkplaceForEdit, setSelectedWorkplaceForEdit] = useState<number | null>(null);
-  const [editingWorkplace, setEditingWorkplace] = useState<WorkplaceDetails | null>(null);
 
-  // 근무지 목록 조회
   useEffect(() => {
     const fetchWorkplaces = async () => {
       try {
         const response = await getWorkplaces();
         const workplacesData = (response.data || []) as WorkplaceDetails[];
         setWorkplaces(workplacesData);
-        if (workplacesData.length > 0 && !selectedWorkplaceId) {
+        if (workplacesData.length > 0) {
           const firstWorkplace = workplacesData[0];
           if (firstWorkplace) {
             setSelectedWorkplaceId(firstWorkplace.id);
           }
         }
-      } catch (error) {
+      } catch {
         setWorkplaces([]);
       } finally {
         setIsLoading(false);
@@ -96,212 +35,10 @@ export function useWorkplaceManagement({
     fetchWorkplaces();
   }, []);
 
-  const handleManageWorkplaces = () => {
-    setIsManagingWorkplaces(true);
-    setIsAddingWorkplace(false);
-    setSelectedWorkplaceForEdit(null);
-    setEditingWorkplace(null);
-  };
-
-  const handleCancelManageWorkplaces = () => {
-    setIsManagingWorkplaces(false);
-    setSelectedWorkplaceForEdit(null);
-    setEditingWorkplace(null);
-  };
-
-  const handleAddWorkplaceFromManage = () => {
-    setIsManagingWorkplaces(false);
-    setIsAddingWorkplace(true);
-    setSelectedWorkplaceForEdit(null);
-    setEditingWorkplace(null);
-    setNewWorkplaceName("");
-    setNewWorkplaceAddress("");
-    setNewWorkplaceBusinessNumber("");
-    setNewWorkplaceIsSmallBusiness(false);
-  };
-
-  const handleAddWorkplace = async () => {
-    const workplaceName = newWorkplaceName.trim();
-
-    if (!workplaceName) {
-      Alert.alert("입력 확인", "근무지 이름을 입력해주세요.");
-      return;
-    }
-
-    if (workplaces.some((wp) => wp.name === workplaceName)) {
-      Alert.alert("입력 확인", "이미 존재하는 근무지입니다.");
-      return;
-    }
-
-    try {
-      const response = await createWorkplace({
-        name: workplaceName,
-        address: newWorkplaceAddress.trim(),
-        businessNumber: newWorkplaceBusinessNumber.trim(),
-        isLessThanFiveEmployees: newWorkplaceIsSmallBusiness,
-      });
-      const createdWorkplace = response.data as WorkplaceDetails;
-
-      setWorkplaces((prev) => [...prev, createdWorkplace]);
-      setSelectedWorkplaceId(createdWorkplace.id);
-      setIsAddingWorkplace(false);
-      setNewWorkplaceName("");
-      setNewWorkplaceAddress("");
-      setNewWorkplaceBusinessNumber("");
-      setNewWorkplaceIsSmallBusiness(false);
-
-      onWorkplaceChanged?.(createdWorkplace.id);
-    } catch {
-      showError("추가 실패", "근무지 추가 중 오류가 발생했습니다.");
-    }
-  };
-
-  const handleCancelAddWorkplace = () => {
-    setIsAddingWorkplace(false);
-    setNewWorkplaceName("");
-    setNewWorkplaceAddress("");
-    setNewWorkplaceBusinessNumber("");
-    setNewWorkplaceIsSmallBusiness(false);
-  };
-
-  const handleDeleteWorkplace = () => {
-    if (!selectedWorkplaceId) return;
-
-    const workplaceToDelete = workplaces.find((wp) => wp.id === selectedWorkplaceId);
-    if (!workplaceToDelete) return;
-
-    Alert.alert(
-      "근무지 삭제",
-      `${workplaceToDelete.name}을(를) 삭제하시겠습니까?`,
-      [
-        { text: "취소", style: "cancel" },
-        {
-          text: "삭제",
-          style: "destructive",
-          onPress: async () => {
-            const updatedWorkplaces = workplaces.filter((wp) => wp.id !== selectedWorkplaceId);
-            if (updatedWorkplaces.length === 0) {
-              showError("삭제 실패", "최소 하나의 근무지는 필요합니다.");
-              return;
-            }
-            try {
-              await deleteWorkplace(selectedWorkplaceId);
-              setWorkplaces(updatedWorkplaces);
-              const firstWorkplace = updatedWorkplaces[0];
-              if (firstWorkplace) setSelectedWorkplaceId(firstWorkplace.id);
-              onWorkplaceDeleted?.(selectedWorkplaceId);
-            } catch {
-              showError("삭제 실패", "근무지 삭제 중 오류가 발생했습니다.");
-            }
-          },
-        },
-      ]
-    );
-  };
-
-  const handleEditWorkplace = (workplace: WorkplaceDetails) => {
-    setEditingWorkplace({
-      id: workplace.id,
-      name: workplace.name || "",
-      address: workplace.address || "",
-      businessNumber: workplace.businessNumber || "",
-      isSmallBusiness: workplace.isSmallBusiness || false,
-    });
-    setSelectedWorkplaceForEdit(workplace.id);
-  };
-
-  const handleSaveWorkplaceEdit = async () => {
-    if (!editingWorkplace) return;
-
-    if (!editingWorkplace.name.trim()) {
-      Alert.alert("입력 확인", "근무지 이름을 입력해주세요.");
-      return;
-    }
-
-    const isDuplicate = workplaces.some(
-      (wp) => wp.name === editingWorkplace.name.trim() && wp.id !== editingWorkplace.id
-    );
-    if (isDuplicate) {
-      Alert.alert("입력 확인", "이미 존재하는 근무지입니다.");
-      return;
-    }
-
-    try {
-      await updateWorkplace(editingWorkplace.id, {
-        name: editingWorkplace.name.trim(),
-        address: editingWorkplace.address?.trim() ?? "",
-        isLessThanFiveEmployees: !!editingWorkplace.isSmallBusiness,
-      });
-
-      setWorkplaces((prev) =>
-        prev.map((wp) =>
-          wp.id === editingWorkplace.id
-            ? {
-                ...wp,
-                name: editingWorkplace.name.trim(),
-                address: editingWorkplace.address?.trim() ?? "",
-                businessNumber: editingWorkplace.businessNumber?.trim() ?? "",
-                isSmallBusiness: !!editingWorkplace.isSmallBusiness,
-              }
-            : wp
-        )
-      );
-
-      setEditingWorkplace(null);
-      setSelectedWorkplaceForEdit(null);
-      onWorkplaceChanged?.(editingWorkplace.id);
-    } catch {
-      showError("수정 실패", "근무지 수정 중 오류가 발생했습니다.");
-    }
-  };
-
-  const handleCancelWorkplaceEdit = () => {
-    setEditingWorkplace(null);
-    setSelectedWorkplaceForEdit(null);
-  };
-
-  const handleEditingWorkplaceChange = (data: {
-    name?: string;
-    address?: string;
-    businessNumber?: string;
-    isSmallBusiness?: boolean;
-  }) => {
-    setEditingWorkplace((prev) => (prev ? { ...prev, ...data } : prev));
-  };
-
   return {
     workplaces,
     isLoading,
     selectedWorkplaceId,
-    isAddingWorkplace,
-    isManagingWorkplaces,
-    selectedWorkplaceForEdit,
-    editingWorkplace,
-    newWorkplaceName,
-    newWorkplaceAddress,
-    newWorkplaceBusinessNumber,
-    newWorkplaceIsSmallBusiness,
-
-    setWorkplaces,
     setSelectedWorkplaceId,
-    setIsAddingWorkplace,
-    setIsManagingWorkplaces,
-    setSelectedWorkplaceForEdit,
-    setEditingWorkplace,
-    setNewWorkplaceName,
-    setNewWorkplaceAddress,
-    setNewWorkplaceBusinessNumber,
-    setNewWorkplaceIsSmallBusiness,
-
-    handleManageWorkplaces,
-    handleCancelManageWorkplaces,
-    handleAddWorkplaceFromManage,
-    handleAddWorkplace,
-    handleCancelAddWorkplace,
-    handleDeleteWorkplace,
-    handleEditWorkplace,
-    handleSaveWorkplaceEdit,
-    handleCancelWorkplaceEdit,
-    handleEditingWorkplaceChange,
   };
 }

--- a/src/screens/employer/mypage/EmployerWorkplaceManageScreen.tsx
+++ b/src/screens/employer/mypage/EmployerWorkplaceManageScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { StyleSheet, View, ActivityIndicator, ScrollView } from "react-native";
+import { StyleSheet, ActivityIndicator, ScrollView, Alert } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -16,7 +16,7 @@ import EmployerNavigationBar, {
 import EmployerWorkplaceCard from "../../../components/employer/mypage/EmployerWorkplaceCard";
 import AddWorkplaceButton from "../../../components/employer/mypage/AddWorkplaceButton";
 import AddWorkplaceModal from "../../../components/employer/mypage/AddWorkplaceModal";
-import { getWorkplaces, getWorkplaceDetail } from "../../../api/employer";
+import { getWorkplaces, getWorkplaceDetail, deleteWorkplace } from "../../../api/employer";
 import type { WorkplaceListItem, WorkplaceDetail } from "../../../api/employer/types";
 import type { EmployerStackParamList } from "../../../navigation/EmployerStack";
 import { useEmployerDrawer } from "../../../hooks/employer/useEmployerDrawer";
@@ -73,6 +73,24 @@ const EmployerWorkplaceManageScreen: React.FC = () => {
 		}
 	};
 
+	const handleDeleteWorkplace = (id: number, name: string) => {
+		Alert.alert("근무지 삭제", `${name}을(를) 삭제하시겠습니까?`, [
+			{ text: "취소", style: "cancel" },
+			{
+				text: "삭제",
+				style: "destructive",
+				onPress: async () => {
+					try {
+						await deleteWorkplace(id);
+						fetchWorkplaces();
+					} catch {
+						Alert.alert("삭제 실패", "근무지 삭제 중 오류가 발생했습니다.");
+					}
+				},
+			},
+		]);
+	};
+
 	useEffect(() => {
 		fetchWorkplaces();
 	}, []);
@@ -109,6 +127,7 @@ const EmployerWorkplaceManageScreen: React.FC = () => {
 									colorCode={w.colorCode}
 									businessNumber={detail?.businessNumber}
 									address={detail?.address}
+									onDelete={() => handleDeleteWorkplace(w.id, w.name)}
 								/>
 							);
 						})}

--- a/src/screens/employer/mypage/EmployerWorkplaceManageScreen.tsx
+++ b/src/screens/employer/mypage/EmployerWorkplaceManageScreen.tsx
@@ -20,6 +20,7 @@ import { getWorkplaces, getWorkplaceDetail, deleteWorkplace } from "../../../api
 import type { WorkplaceListItem, WorkplaceDetail } from "../../../api/employer/types";
 import type { EmployerStackParamList } from "../../../navigation/EmployerStack";
 import { useEmployerDrawer } from "../../../hooks/employer/useEmployerDrawer";
+import { showError } from "../../../utils/alert";
 
 const TAB_SCREEN_MAP: Record<EmployerTabName, keyof EmployerStackParamList> = {
 	home: "EmployerHomeMain",
@@ -37,6 +38,7 @@ const EmployerWorkplaceManageScreen: React.FC = () => {
 	const [detailMap, setDetailMap] = useState<Record<number, WorkplaceDetail>>({});
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
+	const [deletingId, setDeletingId] = useState<number | null>(null);
 
 	const handleTabPress = (tab: EmployerTabName) => {
 		navigation.replace(TAB_SCREEN_MAP[tab]);
@@ -74,17 +76,21 @@ const EmployerWorkplaceManageScreen: React.FC = () => {
 	};
 
 	const handleDeleteWorkplace = (id: number, name: string) => {
+		if (deletingId !== null) return;
 		Alert.alert("근무지 삭제", `${name}을(를) 삭제하시겠습니까?`, [
 			{ text: "취소", style: "cancel" },
 			{
 				text: "삭제",
 				style: "destructive",
 				onPress: async () => {
+					setDeletingId(id);
 					try {
 						await deleteWorkplace(id);
 						fetchWorkplaces();
 					} catch {
-						Alert.alert("삭제 실패", "근무지 삭제 중 오류가 발생했습니다.");
+						showError("삭제 실패", "근무지 삭제 중 오류가 발생했습니다.");
+					} finally {
+						setDeletingId(null);
 					}
 				},
 			},
@@ -127,7 +133,7 @@ const EmployerWorkplaceManageScreen: React.FC = () => {
 									colorCode={w.colorCode}
 									businessNumber={detail?.businessNumber}
 									address={detail?.address}
-									onDelete={() => handleDeleteWorkplace(w.id, w.name)}
+									onDelete={deletingId === null ? () => handleDeleteWorkplace(w.id, w.name) : undefined}
 								/>
 							);
 						})}


### PR DESCRIPTION
## 📌 Issue number and Link
closed #44

## ✏️ Summary
고용주 근무지 관리 화면에서 각 근무지 카드에 삭제 버튼을 추가합니다.
삭제 확인 Alert 후 API를 호출하고 목록을 갱신합니다.

## 📝 Changes
- `EmployerWorkplaceCard`: 카드 우측 상단에 휴지통 아이콘 버튼 추가 (`onDelete` prop)
- `EmployerWorkplaceManageScreen`: 삭제 핸들러 추가 (Alert 확인 → `DELETE /api/employer/workplaces/{id}` 호출 → 목록 갱신)
- `useWorkplaceManagement`: 실제로 사용되지 않는 상태/핸들러 제거 (EmployerWorkplaceManageScreen은 현재 훅을 사용하지 않고 자체 state로 구현되어 있음)

## 🔎 PR Type

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot