### PR TITLE
[Fix] @react-native-cookies/cookies 제거 및 refreshToken body 전송으로 전환 (#53)

### DIFF
--- a/docs/exec-plans/active/2026-04-07-issue-53-refresh-token-body.md
+++ b/docs/exec-plans/active/2026-04-07-issue-53-refresh-token-body.md
@@ -1,0 +1,51 @@
+# Issue #53: [Bug] 리프레시 토큰으로 액세스 토큰 재발급이 안됨
+
+## GitHub Issue
+https://github.com/Team-PayCheck/PayCheck-mobile/issues/53
+
+## 목표
+- `@react-native-cookies/cookies` 완전 제거
+- refreshToken을 Zustand에 저장 → refresh 요청 시 body로 전송
+- New Architecture 호환 + 앱 실행 불가 문제 해결
+
+## 현재 상태
+구현 완료
+
+## 작업 범위
+- 라우팅: 직접 수정 (훅/API 로직)
+- 관련 도메인: common (auth)
+
+## 남은 작업
+- [x] `auth/types.ts` — `AuthSuccessData`에 `refreshToken` 추가
+- [x] `authStore.ts` — `refreshToken` 필드 + `setRefreshToken` + `login` 시그니처 업데이트
+- [x] `axios.ts` — CookieManager 제거, refreshToken body 전송
+- [x] `auth/index.ts` — CookieManager 제거, logout 정리
+- [x] `WelcomeScreen.tsx` — authLogin에 refreshToken 전달
+- [x] `Step4AlarmScreen.tsx` — authLogin에 refreshToken 전달
+- [x] `EmployerWithdrawScreen.tsx` — CookieManager 제거
+- [x] `WorkerWithdrawScreen.tsx` — CookieManager 제거
+- [x] `package.json` — @react-native-cookies/cookies 제거
+
+## 관련 파일
+- `src/api/auth/types.ts`
+- `src/stores/authStore.ts`
+- `src/api/axios.ts`
+- `src/api/auth/index.ts`
+- `src/screens/onboarding/WelcomeScreen.tsx`
+- `src/screens/auth/signup/Step4AlarmScreen.tsx`
+- `src/screens/employer/mypage/EmployerWithdrawScreen.tsx`
+- `src/screens/worker/mypage/WorkerWithdrawScreen.tsx`
+
+## API 의존성
+- `POST /api/auth/refresh` — body: `{ refreshToken }` 로 변경 (백엔드 수정 필요)
+- `POST /api/auth/kakao/login` — 응답에 `refreshToken` 포함 (백엔드 수정 필요)
+- `POST /api/auth/kakao/register` — 응답에 `refreshToken` 포함 (백엔드 수정 필요)
+
+## 완료 기준
+- `@react-native-cookies/cookies` 코드베이스에서 완전 제거
+- 앱 런타임 에러 없이 실행
+- 백엔드 반영 후 refresh 토큰 갱신 정상 동작
+
+## 메모
+- 백엔드 수정이 선행되어야 refresh 흐름 완전 동작
+- 백엔드 미반영 상태에서도 앱은 정상 실행됨 (refreshToken이 null이면 401 → 로그아웃 처리)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@expo/ngrok": "^4.1.3",
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "2.2.0",
-    "@react-native-cookies/cookies": "^6.2.1",
     "@react-native-seoul/kakao-login": "^5.4.2",
     "@react-navigation/native": "^7.1.28",
     "@react-navigation/native-stack": "^7.12.0",

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,5 +1,4 @@
 import { AxiosError } from "axios";
-import CookieManager from "@react-native-cookies/cookies";
 import api from "../axios";
 import { getAuthState } from "../../stores/authStore";
 import type {
@@ -69,7 +68,6 @@ export const logout = async (): Promise<void> => {
 		await api.post("/api/auth/logout", {});
 	} finally {
 		getAuthState().logout();
-		await CookieManager.clearAll();
 	}
 };
 

--- a/src/api/auth/types.ts
+++ b/src/api/auth/types.ts
@@ -1,6 +1,7 @@
 // 인증 성공 데이터 (백엔드 API 응답 형태)
 export interface AuthSuccessData {
 	accessToken: string;
+	refreshToken?: string;
 	userType: "EMPLOYER" | "WORKER";
 	userId: number;
 	name: string;

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -3,7 +3,6 @@ import axios, {
 	AxiosError,
 	InternalAxiosRequestConfig,
 } from "axios";
-import CookieManager from "@react-native-cookies/cookies";
 import Constants from "expo-constants";
 import { getAuthState } from "../stores/authStore";
 import type {
@@ -24,7 +23,6 @@ export const api = axios.create({
 		"Content-Type": "application/json",
 		Accept: "application/json",
 	},
-	withCredentials: true, // 쿠키 전송 활성화
 });
 
 // 로그아웃 콜백 (네비게이션 처리용)
@@ -34,10 +32,9 @@ export const setLogoutCallback = (callback: () => void) => {
 	logoutCallback = callback;
 };
 
-// 인증 실패 시 처리 (Zustand + 쿠키 삭제)
-const handleAuthFailure = async () => {
+// 인증 실패 시 처리 (Zustand 초기화)
+const handleAuthFailure = () => {
 	getAuthState().logout();
-	await CookieManager.clearAll();
 	logoutCallback?.();
 };
 
@@ -110,35 +107,38 @@ api.interceptors.response.use(
 			isRefreshing = true;
 
 			try {
-				// React Native는 withCredentials로 쿠키가 자동 전송되지 않아
-				// CookieManager로 쿠키를 직접 읽어 Cookie 헤더에 수동 첨부
-				const cookies = await CookieManager.get(API_BASE_URL);
-				const cookieHeader = Object.entries(cookies)
-					.map(([key, cookie]) => `${key}=${cookie.value}`)
-					.join("; ");
+				const { refreshToken } = getAuthState();
 
-				// Refresh Token(쿠키)으로 새 Access Token 요청
+				if (!refreshToken) {
+					const noTokenError = new Error("리프레시 토큰이 없습니다");
+					onRefreshFailed(noTokenError);
+					handleAuthFailure();
+					return Promise.reject(noTokenError);
+				}
+
+				// Refresh Token을 body로 전송하여 새 Access Token 요청
 				const response = await axios.post<ApiResponse<AuthSuccessData>>(
 					`${API_BASE_URL}/api/auth/refresh`,
-					{},
-					{
-						withCredentials: true,
-						headers: cookieHeader ? { Cookie: cookieHeader } : undefined,
-					}
+					{ refreshToken }
 				);
 
 				const newAccessToken = response.data.data?.accessToken;
+				const newRefreshToken = response.data.data?.refreshToken;
+
 				if (!newAccessToken) {
 					const noTokenError = new Error(
 						"토큰 갱신 응답에 accessToken이 없습니다"
 					);
 					onRefreshFailed(noTokenError);
-					await handleAuthFailure();
+					handleAuthFailure();
 					return Promise.reject(noTokenError);
 				}
 
-				// 새 토큰 저장 (Zustand → 자동으로 AsyncStorage에도 persist)
+				// 새 토큰 저장
 				getAuthState().setAccessToken(newAccessToken);
+				if (newRefreshToken) {
+					getAuthState().setRefreshToken(newRefreshToken);
+				}
 
 				// 대기 중인 요청들에 새 토큰 전달
 				onRefreshed(newAccessToken);
@@ -151,7 +151,7 @@ api.interceptors.response.use(
 			} catch (refreshError) {
 				// 갱신 실패 → 대기 요청 모두 reject 후 로그아웃
 				onRefreshFailed(refreshError);
-				await handleAuthFailure();
+				handleAuthFailure();
 				return Promise.reject(refreshError);
 			} finally {
 				isRefreshing = false;

--- a/src/screens/auth/signup/Step4AlarmScreen.tsx
+++ b/src/screens/auth/signup/Step4AlarmScreen.tsx
@@ -60,7 +60,7 @@ const Step4AlarmScreen: React.FC = () => {
 					userId: response.data.userId,
 					name: response.data.name,
 					userType: response.data.userType as "EMPLOYER" | "WORKER",
-				});
+				}, response.data.refreshToken);
 
 				return true;
 			}

--- a/src/screens/employer/mypage/EmployerWithdrawScreen.tsx
+++ b/src/screens/employer/mypage/EmployerWithdrawScreen.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { Alert, StyleSheet, View, Image, TouchableOpacity, ActivityIndicator } from "react-native";
 import { deleteMyAccount } from "../../../api/auth";
 import { useAuthStore } from "../../../stores/authStore";
-import CookieManager from "@react-native-cookies/cookies";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import HomeBackButton from "../../../components/common/HomeBackButton";
@@ -37,7 +36,6 @@ const EmployerWithdrawScreen: React.FC<Props> = ({ navigation }) => {
           text: "확인",
           onPress: async () => {
             useAuthStore.getState().logout();
-            await CookieManager.clearAll();
             navigation.getParent()?.reset({ index: 0, routes: [{ name: "Welcome" }] });
           },
         },

--- a/src/screens/onboarding/WelcomeScreen.tsx
+++ b/src/screens/onboarding/WelcomeScreen.tsx
@@ -49,7 +49,7 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({
 					userType: loginResult.data.userType,
 					userId: loginResult.data.userId,
 					name: loginResult.data.name,
-				});
+				}, loginResult.data.refreshToken);
 
 				// userType에 따라 콜백 호출
 				onLoginSuccess?.(loginResult.data.userType);

--- a/src/screens/worker/mypage/WorkerWithdrawScreen.tsx
+++ b/src/screens/worker/mypage/WorkerWithdrawScreen.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { Alert, StyleSheet, View, Image, TouchableOpacity, ActivityIndicator } from "react-native";
 import { deleteMyAccount } from "../../../api/auth";
 import { useAuthStore } from "../../../stores/authStore";
-import CookieManager from "@react-native-cookies/cookies";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import HomeBackButton from "../../../components/common/HomeBackButton";
@@ -47,7 +46,6 @@ const WithdrawScreen: React.FC<Props> = ({ navigation }) => {
 					text: "확인",
 					onPress: async () => {
 						useAuthStore.getState().logout();
-						await CookieManager.clearAll();
 						navigation.getParent()?.reset({ index: 0, routes: [{ name: "Welcome" }] });
 					},
 				},

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -6,14 +6,16 @@ import type { UserInfo } from "../api/auth/types";
 interface AuthState {
 	// 상태
 	accessToken: string | null;
+	refreshToken: string | null;
 	userInfo: UserInfo | null;
 	isLoggedIn: boolean;
 	isHydrated: boolean;
 
 	// 액션
 	setAccessToken: (token: string) => void;
+	setRefreshToken: (token: string) => void;
 	setUserInfo: (info: UserInfo) => void;
-	login: (token: string, userInfo: UserInfo) => void;
+	login: (token: string, userInfo: UserInfo, refreshToken?: string) => void;
 	logout: () => void;
 	setHydrated: (hydrated: boolean) => void;
 }
@@ -23,6 +25,7 @@ export const useAuthStore = create<AuthState>()(
 		(set) => ({
 			// 초기 상태
 			accessToken: null,
+			refreshToken: null,
 			userInfo: null,
 			isLoggedIn: false,
 			isHydrated: false,
@@ -31,11 +34,15 @@ export const useAuthStore = create<AuthState>()(
 			setAccessToken: (token) =>
 				set({ accessToken: token, isLoggedIn: true }),
 
+			setRefreshToken: (token) =>
+				set({ refreshToken: token }),
+
 			setUserInfo: (info) => set({ userInfo: info }),
 
-			login: (token, userInfo) =>
+			login: (token, userInfo, refreshToken) =>
 				set({
 					accessToken: token,
+					refreshToken: refreshToken ?? null,
 					userInfo,
 					isLoggedIn: true,
 				}),
@@ -43,6 +50,7 @@ export const useAuthStore = create<AuthState>()(
 			logout: () =>
 				set({
 					accessToken: null,
+					refreshToken: null,
 					userInfo: null,
 					isLoggedIn: false,
 				}),
@@ -55,6 +63,7 @@ export const useAuthStore = create<AuthState>()(
 			// isHydrated는 persist하지 않음
 			partialize: (state) => ({
 				accessToken: state.accessToken,
+				refreshToken: state.refreshToken,
 				userInfo: state.userInfo,
 				isLoggedIn: state.isLoggedIn,
 			}),


### PR DESCRIPTION
## Summary

- `@react-native-cookies/cookies` 완전 제거 (New Architecture 미호환으로 앱 실행 불가 원인)
- refreshToken을 Zustand + AsyncStorage에 저장
- `/api/auth/refresh` 호출 시 쿠키 대신 request body로 refreshToken 전송

## 변경 사항

| 파일 | 내용 |
|------|------|
| `package.json` | `@react-native-cookies/cookies` 제거 |
| `src/api/auth/types.ts` | `AuthSuccessData`에 `refreshToken?: string` 추가 |
| `src/stores/authStore.ts` | `refreshToken` 필드 + `setRefreshToken` 액션 추가 |
| `src/api/axios.ts` | CookieManager 제거, refreshToken body 전송으로 변경 |
| `src/api/auth/index.ts` | CookieManager 제거, logout 단순화 |
| `src/screens/onboarding/WelcomeScreen.tsx` | 로그인 시 refreshToken 저장 |
| `src/screens/auth/signup/Step4AlarmScreen.tsx` | 회원가입 시 refreshToken 저장 |
| `src/screens/employer/mypage/EmployerWithdrawScreen.tsx` | CookieManager 제거 |
| `src/screens/worker/mypage/WorkerWithdrawScreen.tsx` | CookieManager 제거 |

## Test plan

- [x] 앱 정상 실행 (`runtime not ready` 에러 해소)
- [x] 로그인 정상 동작
- [ ] accessToken 만료 시 자동 갱신 (백엔드 반영 후 테스트 필요)

## 백엔드 의존성

백엔드 수정 완료 후 refresh 흐름 전체 동작 → [PayCheck-backend#132](https://github.com/Team-PayCheck/PayCheck-backend/issues/132)

## 관련 이슈

Closes #53