### PR TITLE
[Fix] 익일 근무(야간 근무) 시 고용주 타임라인 표시 누락 수정 (#62)

### DIFF
--- a/src/components/employer/home/EmployerTimeline.tsx
+++ b/src/components/employer/home/EmployerTimeline.tsx
@@ -23,9 +23,13 @@ const minutesToX = (minutes: number): number =>
 
 interface EmployerTimelineProps {
   workRecords: WorkRecord[];
+  selectedDate: string;
 }
 
-const EmployerTimeline: React.FC<EmployerTimelineProps> = ({ workRecords }) => {
+const EmployerTimeline: React.FC<EmployerTimelineProps> = ({
+  workRecords,
+  selectedDate,
+}) => {
   const scrollRef = useRef<ScrollView>(null);
 
   const now = new Date();
@@ -103,10 +107,26 @@ const EmployerTimeline: React.FC<EmployerTimelineProps> = ({ workRecords }) => {
             {/* 근무자 바 */}
             {workRecords.map((record, index) => {
               const startMin = timeToMinutes(record.startTime);
-              let endMin = timeToMinutes(record.endTime);
-              if (endMin <= startMin) endMin += 24 * 60; // 자정 넘는 근무
-              const barLeft = minutesToX(startMin);
-              const barWidth = Math.max(minutesToX(endMin - startMin), 48);
+              const endMin = timeToMinutes(record.endTime);
+              const isPrevDay = record.workDate !== selectedDate;
+              const overnight = endMin <= startMin;
+
+              // 자정을 넘는 근무는 시작 날짜와 종료 날짜 양쪽에서 분할 표시한다.
+              // - 전날 시작: 0:00 ~ endTime
+              // - 당일 시작 + 자정 넘김: startTime ~ 24:00
+              // - 그 외: startTime ~ endTime
+              const displayStart = isPrevDay ? 0 : startMin;
+              const displayEnd = isPrevDay
+                ? endMin
+                : overnight
+                  ? 24 * 60
+                  : endMin;
+
+              const barLeft = minutesToX(displayStart);
+              const barWidth = Math.max(
+                minutesToX(displayEnd - displayStart),
+                48
+              );
               const barTop = ROW_GAP + index * (BAR_HEIGHT + ROW_GAP);
               const barColor = WORK_STATUS_COLOR[getWorkStatus(record)];
 

--- a/src/hooks/employer/useEmployerDailyWorkRecords.ts
+++ b/src/hooks/employer/useEmployerDailyWorkRecords.ts
@@ -2,6 +2,24 @@ import { useState, useEffect, useCallback } from "react";
 import type { WorkRecord } from "../../api/employer/types";
 import { getWorkRecords } from "../../api/employer";
 
+const getPrevDateStr = (dateStr: string): string => {
+  const d = new Date(`${dateStr}T00:00:00`);
+  d.setDate(d.getDate() - 1);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+};
+
+const timeToMinutes = (time: string): number => {
+  const [h = "0", m = "0"] = time.split(":");
+  return parseInt(h, 10) * 60 + parseInt(m, 10);
+};
+
+// 자정을 넘는 근무: 종료 시각이 시작 시각보다 같거나 작음
+const isOvernight = (record: WorkRecord): boolean =>
+  timeToMinutes(record.endTime) <= timeToMinutes(record.startTime);
+
 const useEmployerDailyWorkRecords = (
   workplaceId: number | null,
   date: string
@@ -16,8 +34,18 @@ const useEmployerDailyWorkRecords = (
     }
     setIsLoading(true);
     try {
-      const response = await getWorkRecords(workplaceId, date, date);
-      setWorkRecords((response.data ?? []) as WorkRecord[]);
+      const prevDate = getPrevDateStr(date);
+      const response = await getWorkRecords(workplaceId, prevDate, date);
+      const all = (response.data ?? []) as WorkRecord[];
+      // 선택일에 보여줘야 할 근무만 필터링:
+      // - 선택일 시작 근무는 전부
+      // - 전날 시작 근무는 자정을 넘기는 경우만 (익일 0시~endTime 구간을 표시)
+      const filtered = all.filter((r) => {
+        if (r.workDate === date) return true;
+        if (r.workDate === prevDate) return isOvernight(r);
+        return false;
+      });
+      setWorkRecords(filtered);
     } catch {
       setWorkRecords([]);
     } finally {

--- a/src/screens/employer/EmployerHomeScreen.tsx
+++ b/src/screens/employer/EmployerHomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import {
   StyleSheet,
   ScrollView,
@@ -50,12 +50,11 @@ const EmployerHomeScreen: React.FC = () => {
 
   const { openDrawer, drawerProps, accountSheetProps } = useEmployerDrawer(navigation);
 
-  const today = useMemo(() => new Date(), []);
-  const [selectedDate, setSelectedDate] = useState<Date>(today);
+  const [selectedDate, setSelectedDate] = useState<Date>(() => new Date());
   const [isCalendarModalVisible, setIsCalendarModalVisible] = useState(false);
   const [isAddWorkModalVisible, setIsAddWorkModalVisible] = useState(false);
-  const [calendarYear, setCalendarYear] = useState(today.getFullYear());
-  const [calendarMonth, setCalendarMonth] = useState(today.getMonth());
+  const [calendarYear, setCalendarYear] = useState(() => new Date().getFullYear());
+  const [calendarMonth, setCalendarMonth] = useState(() => new Date().getMonth());
 
   const {
     workplaces,
@@ -212,7 +211,10 @@ const EmployerHomeScreen: React.FC = () => {
               </View>
             ) : (
               <>
-                <EmployerTimeline workRecords={workRecords} />
+                <EmployerTimeline
+                  workRecords={workRecords}
+                  selectedDate={dateStr}
+                />
                 <EmployerWorkerListSection
                   workRecords={workRecords}
                   onPressAdd={() => setIsAddWorkModalVisible(true)}


### PR DESCRIPTION
## Summary
- 자정을 넘는 야간 근무가 종료 날짜 타임라인에 표시되지 않던 버그 수정
- 훅에서 선택일 + 전날 범위로 조회 후 전날 자정 넘는 근무만 포함하도록 필터링
- 타임라인은 `selectedDate` prop을 받아 전날 시작 근무는 `0:00~endTime`, 당일 자정 넘는 근무는 `startTime~24:00`로 분할 표시
- `EmployerHomeScreen`의 `today useMemo`를 `useState` lazy initializer로 정리

Closes #62

## 변경 파일
- `src/hooks/employer/useEmployerDailyWorkRecords.ts`
- `src/components/employer/home/EmployerTimeline.tsx`
- `src/screens/employer/EmployerHomeScreen.tsx`

## Test plan
- [x] 자정 넘는 근무(예: 23시~익일 02시) 등록 후 시작일/종료일 양쪽 타임라인에 분할 표시되는지 확인
- [x] 일반(자정 안 넘는) 근무가 기존과 동일하게 표시되는지 회귀 확인
- [ ] 월/년 경계 케이스(예: 1월 1일 선택 시 전날 12월 31일 조회) 확인
- [x] `tsc --noEmit` 통과