### PR TITLE
[Fix] 근로자 공지 게시판 근무지 선택 기능 누락 수정 (#51)

### DIFF
--- a/src/components/common/NoticeBoard.tsx
+++ b/src/components/common/NoticeBoard.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { StyleSheet, View, ScrollView, TouchableOpacity } from "react-native";
 import { Text } from "./Text";
 import NoticeCard from "./NoticeCard";
+import WorkplaceTabSelector from "../worker/salary/WorkplaceTabSelector";
 import { colors } from "../../constants/colors";
 import type { NoticeCardItem } from "../../types/common/notice.types";
 
@@ -12,13 +13,21 @@ interface NoticeBoardProps {
 	notices: NoticeCardItem[];
 	onPressAdd?: () => void;
 	onPressNotice?: (notice: NoticeCardItem) => void;
+	workplaceNames?: string[];
+	selectedWorkplaceIndex?: number;
+	onWorkplaceSelect?: (index: number) => void;
 }
 
 const NoticeBoard: React.FC<NoticeBoardProps> = ({
 	notices,
 	onPressAdd,
 	onPressNotice,
+	workplaceNames,
+	selectedWorkplaceIndex = 0,
+	onWorkplaceSelect,
 }) => {
+	const hasMultipleWorkplaces = workplaceNames && workplaceNames.length > 1;
+
 	return (
 		<View style={styles.container}>
 			{/* 헤더 */}
@@ -36,6 +45,15 @@ const NoticeBoard: React.FC<NoticeBoardProps> = ({
 					</Text>
 				</TouchableOpacity>
 			</View>
+
+			{/* 근무지 탭 (근무지가 2개 이상일 때만 표시) */}
+			{hasMultipleWorkplaces && (
+				<WorkplaceTabSelector
+					workplaceNames={workplaceNames}
+					selectedIndex={selectedWorkplaceIndex}
+					onSelect={onWorkplaceSelect ?? (() => {})}
+				/>
+			)}
 
 			{/* 카드 가로 스크롤 */}
 			<ScrollView

--- a/src/screens/worker/WorkerWeeklyCalendarScreen.tsx
+++ b/src/screens/worker/WorkerWeeklyCalendarScreen.tsx
@@ -46,12 +46,13 @@ const WorkerWeeklyCalendarScreen: React.FC<Props> = ({ navigation }) => {
 
 	// 근로자 근무지 조회 (공지 게시판용 workplaceId 확보)
 	const { workplaces: workerWorkplaces, fetchWorkplaces } = useWorkplaces();
+	const [selectedWorkplaceIndex, setSelectedWorkplaceIndex] = useState(0);
 
 	useEffect(() => {
 		fetchWorkplaces();
 	}, []);
 
-	const workerWorkplaceId = workerWorkplaces[0]?.workplaceId ?? null;
+	const workerWorkplaceId = workerWorkplaces[selectedWorkplaceIndex]?.workplaceId ?? null;
 
 	// 공지 게시판
 	const {
@@ -151,10 +152,13 @@ const WorkerWeeklyCalendarScreen: React.FC<Props> = ({ navigation }) => {
 				/>
 
 				<NoticeBoard
-				notices={notices}
-				onPressAdd={() => setIsNoticeCreateVisible(true)}
-				onPressNotice={handlePressNotice}
-			/>
+					notices={notices}
+					onPressAdd={() => setIsNoticeCreateVisible(true)}
+					onPressNotice={handlePressNotice}
+					workplaceNames={workerWorkplaces.map((wp) => wp.workplaceName)}
+					selectedWorkplaceIndex={selectedWorkplaceIndex}
+					onWorkplaceSelect={setSelectedWorkplaceIndex}
+				/>
 
 				{isLoading ? (
 					<ActivityIndicator


### PR DESCRIPTION
## 📌 Issue number and Link

closed #51

## ✏️ Summary

근로자가 공지 게시판에서 글을 작성할 때 어느 근무지의 게시판인지 선택할 수 없던 문제를 수정

근무지별 공지 목록 조회와 작성이 일관되게 동작하도록
공지 추가 모달이 아닌 NoticeBoard 컴포넌트 내부에 근무지 선택 탭을 배치

## 📝 Changes

- **`NoticeBoard`** — `workplaceNames`, `selectedWorkplaceIndex`, `onWorkplaceSelect` props 추가. 근무지가 2개 이상일 때 헤더 아래에 `WorkplaceTabSelector` 렌더링 (1개이면 탭 미노출)
- **`WorkerWeeklyCalendarScreen`** — `selectedWorkplaceIndex` 상태 추가, 선택된 인덱스 기준으로 `workplaceId`를 도출하여 `useNotices`에 전달. `NoticeBoard`에 근무지 탭 props 바인딩

## 🔎 PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot

<img width="663" height="1440" alt="image" src="https://github.com/user-attachments/assets/f2371131-1a60-4f93-8ea0-ae68c4756082" />