### PR TITLE
[Fix] 가입 시 푸시 알림 자동 활성화 및 알림 설정 디바이스 동기화

### DIFF
--- a/src/hooks/common/useFcmToken.ts
+++ b/src/hooks/common/useFcmToken.ts
@@ -1,8 +1,11 @@
 /**
  * FCM 푸시 토큰 자동 등록 훅.
- * 로그인 상태이고 서버 알림 설정에서 pushEnabled가 true인 경우에만 토큰을 등록한다.
+ * OS 알림 권한이 이미 granted이고 서버 설정의 pushEnabled가 true인 경우에만 토큰을 등록한다.
+ * 사용자가 회원가입 Step4에서 "나중에 설정하기"를 선택한 경우 OS 권한이 미승인 상태이므로
+ * 이 훅이 토큰을 자동 등록하지 않는다.
  */
 import { useEffect } from "react";
+import * as Notifications from "expo-notifications";
 import { useAuthStore } from "../../stores/authStore";
 import { registerPushToken } from "../../utils/pushToken";
 import { getNotificationSettings } from "../../api/settings";
@@ -13,12 +16,16 @@ export function useFcmToken() {
 	useEffect(() => {
 		if (!isLoggedIn) return;
 
-		getNotificationSettings().then((res) => {
-			// 서버 설정 조회 실패 시 기본값으로 허용 처리
+		(async () => {
+			const { status } = await Notifications.getPermissionsAsync();
+			if (status !== "granted") return;
+
+			const res = await getNotificationSettings();
+			// 서버 설정 조회 실패 시 기본값으로 허용 처리 (OS 권한이 이미 있는 경우에만 도달)
 			const pushEnabled = res.success && res.data ? res.data.pushEnabled : true;
 			if (pushEnabled) {
 				registerPushToken();
 			}
-		});
+		})();
 	}, [isLoggedIn]);
 }

--- a/src/screens/common/NotificationSettingsScreen.tsx
+++ b/src/screens/common/NotificationSettingsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import {
 	View,
 	Switch,
@@ -8,6 +8,7 @@ import {
 	Linking,
 	Platform,
 	ActivityIndicator,
+	AppState,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
@@ -16,84 +17,74 @@ import * as Notifications from "expo-notifications";
 import { Text } from "../../components/common/Text";
 import { registerPushToken, unregisterPushToken } from "../../utils/pushToken";
 import { getNotificationSettings, updateNotificationSettings } from "../../api/settings";
-import { showError } from "../../utils/alert";
 import { colors } from "../../constants/colors";
 
 const NotificationSettingsScreen = () => {
 	const navigation = useNavigation();
-	const [pushEnabled, setPushEnabled] = useState(true);
+	const [pushEnabled, setPushEnabled] = useState(false);
 	const [isLoading, setIsLoading] = useState(true);
-	const [isToggling, setIsToggling] = useState(false);
+	const lastGrantedRef = useRef<boolean | null>(null);
 
-	useEffect(() => {
-		getNotificationSettings().then((res) => {
-			if (res.success && res.data) {
-				setPushEnabled(res.data.pushEnabled);
-			}
-			setIsLoading(false);
-		});
-	}, []);
-
-	const handleToggle = useCallback(async (newValue: boolean) => {
-		if (newValue) {
-			// ON으로 바꿀 때: 디바이스 알림 권한 확인
-			const { status } = await Notifications.getPermissionsAsync();
-			if (status !== "granted") {
-				Alert.alert(
-					"알림 권한 필요",
-					"디바이스 설정에서 알림을 허용해주세요.",
-					[
-						{ text: "취소", style: "cancel" },
-						{
-							text: "설정으로 이동",
-							onPress: () => {
-								if (Platform.OS === "ios") {
-									Linking.openURL("app-settings:");
-								} else {
-									Linking.openSettings();
-								}
-							},
-						},
-					]
-				);
-				return;
-			}
-		}
-
-		setIsToggling(true);
-		try {
-			if (newValue) {
-				const success = await registerPushToken();
-				if (!success) {
-					Alert.alert("오류", "푸시 알림 등록에 실패했습니다. 잠시 후 다시 시도해주세요.");
-					return;
-				}
-			} else {
-				await unregisterPushToken();
-			}
-			const res = await updateNotificationSettings({ pushEnabled: newValue });
-			if (!res.success) {
-				// 서버 설정 업데이트 실패 시 FCM 토큰 롤백
-				if (newValue) await unregisterPushToken();
-				else await registerPushToken();
-				showError("오류", "알림 설정 변경에 실패했습니다. 잠시 후 다시 시도해주세요.");
-				return;
-			}
-			setPushEnabled(newValue);
-		} catch {
-			// silent fail
-		} finally {
-			setIsToggling(false);
-		}
-	}, []);
-
-	const openDeviceSettings = () => {
+	const openDeviceSettings = useCallback(() => {
 		if (Platform.OS === "ios") {
 			Linking.openURL("app-settings:");
 		} else {
 			Linking.openSettings();
 		}
-	};
+	}, []);
+
+	// 디바이스 권한 상태를 단일 진실 공급원으로 사용한다.
+	// 표시 상태를 OS 권한에 맞추고, 서버 설정과 다르면 토큰 등록/해제와 함께 동기화한다.
+	const syncWithDevicePermission = useCallback(async () => {
+		const { status } = await Notifications.getPermissionsAsync();
+		const granted = status === "granted";
+		setPushEnabled(granted);
+
+		const isFirstSync = lastGrantedRef.current === null;
+		const deviceChanged = !isFirstSync && lastGrantedRef.current !== granted;
+		lastGrantedRef.current = granted;
+
+		if (isFirstSync || deviceChanged) {
+			const res = await getNotificationSettings();
+			const serverEnabled = res.success && res.data ? res.data.pushEnabled : false;
+			if (serverEnabled !== granted) {
+				try {
+					if (granted) {
+						await registerPushToken();
+					} else {
+						await unregisterPushToken();
+					}
+					await updateNotificationSettings({ pushEnabled: granted });
+				} catch {
+					// 실패 시 다음 포그라운드 진입에서 재동기화되도록 직전 값을 롤백한다.
+					lastGrantedRef.current = !granted;
+				}
+			}
+		}
+
+		setIsLoading(false);
+	}, []);
+
+	useEffect(() => {
+		syncWithDevicePermission();
+		const subscription = AppState.addEventListener("change", (state) => {
+			if (state === "active") {
+				syncWithDevicePermission();
+			}
+		});
+		return () => subscription.remove();
+	}, [syncWithDevicePermission]);
+
+	const handleToggleAttempt = useCallback(() => {
+		Alert.alert(
+			"알림 설정 변경",
+			"푸시 알림은 디바이스 설정에서만 변경할 수 있습니다.",
+			[
+				{ text: "취소", style: "cancel" },
+				{ text: "설정으로 이동", onPress: openDeviceSettings },
+			]
+		);
+	}, [openDeviceSettings]);
 
 	return (
 		<SafeAreaView style={styles.container}>
@@ -117,7 +108,7 @@ const NotificationSettingsScreen = () => {
 				</View>
 			) : (
 				<View style={styles.content}>
-					<View style={styles.settingRow}>
+					<Pressable style={styles.settingRow} onPress={handleToggleAttempt}>
 						<View style={styles.settingInfo}>
 							<Text weight="SemiBold" style={styles.settingTitle}>
 								푸시 알림
@@ -128,15 +119,14 @@ const NotificationSettingsScreen = () => {
 						</View>
 						<Switch
 							value={pushEnabled}
-							onValueChange={handleToggle}
-							disabled={isToggling}
+							onValueChange={handleToggleAttempt}
 							trackColor={{
 								false: colors.disabled,
 								true: colors.primary,
 							}}
 							thumbColor={colors.white}
 						/>
-					</View>
+					</Pressable>
 
 					<Pressable style={styles.linkRow} onPress={openDeviceSettings}>
 						<Text weight="Medium" style={styles.linkText}>
@@ -150,8 +140,8 @@ const NotificationSettingsScreen = () => {
 					</Pressable>
 
 					<Text style={styles.hintText}>
-						디바이스 설정에서 알림 권한을 끄면 푸시 알림이{"\n"}
-						앱 내 설정과 관계없이 수신되지 않습니다.
+						푸시 알림 상태는 디바이스 설정과 항상 동기화됩니다.{"\n"}
+						변경하려면 디바이스 설정에서 알림 권한을 조정해주세요.
 					</Text>
 				</View>
 			)}


### PR DESCRIPTION
## 📌 Issue number and Link
closed #49
https://github.com/Team-PayCheck/PayCheck-mobile/issues/49

## ✏️ Summary
회원가입 Step4에서 "나중에 설정하기"를 선택해도 푸시 알림이 자동 등록되던 버그를 수정합니다. 더불어 iOS에서는 푸시 알림이 OS 권한에 종속된다는 점을 반영해, 알림 설정 화면이 디바이스 권한 상태를 단일 진실 공급원으로 추적하고 변경 시 디바이스 설정으로 유도하도록 개선했습니다.

## 📝 Changes

**`src/hooks/common/useFcmToken.ts`**
- OS 알림 권한이 `granted`일 때만 토큰 등록을 진행하도록 게이트 추가. "나중에 설정하기" 선택 시 `getExpoPushToken` 내부에서 권한이 자동 재요청되며 토큰이 등록되던 경로 차단.

**`src/screens/common/NotificationSettingsScreen.tsx`**
- 표시 상태(`pushEnabled`)를 서버 응답이 아닌 `Notifications.getPermissionsAsync()` 결과로 결정하도록 변경.
- 토글/행 탭 시 즉시 변경하지 않고 "디바이스 설정으로 이동" 안내 alert 표시 (양방향).
- `AppState` 리스너로 포그라운드 진입 시 권한 재확인. 직전 상태와 비교해 변경된 경우에만 서버 `pushEnabled`와 FCM 토큰 등록/해제 동기화.
- 동기화 실패 시 `lastGrantedRef` 롤백으로 다음 진입 때 재시도 보장.

## 🔎 PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot

<img width="603" height="1311" alt="KakaoTalk_Photo_2026-04-29-15-43-57" src="https://github.com/user-attachments/assets/ef8fa699-cece-47f7-9721-3827bf724020" />

iOS 환경에서 다음 시나리오 동작 확인 완료:
- 가입 Step4 "나중에 설정하기" → OS 권한 요청 안 뜸, 설정 화면 토글 OFF
- 가입 Step4 "알람 허용" → 권한 허용 후 토글 ON
- 설정 화면 토글/행 탭 → 안내 alert → 디바이스 설정 이동
- iOS 설정에서 권한 ON↔OFF 후 앱 복귀 → 토글 자동 갱신

> ⚠️ Android 환경 테스트 미수행 — 리뷰 단계에서 Android 회귀 확인 부탁드립니다.