### PR TITLE
[Fix] 주간/월간 캘린더 총 근무시간·예상 근무비 계산 오류 수정 (#55)

### DIFF
--- a/src/screens/worker/WorkerMonthlyCalendarScreen.tsx
+++ b/src/screens/worker/WorkerMonthlyCalendarScreen.tsx
@@ -20,6 +20,7 @@ import useCorrectionRequest from "../../hooks/worker/useCorrectionRequest";
 import { useLogoutHandler } from "../../hooks/common/useLogoutHandler";
 import { WorkerStackParamList } from "../../navigation/WorkerStack";
 import { colors } from "../../constants/colors";
+import { calculateWorkSummary } from "../../utils/workSummary";
 
 const WorkerMonthlyCalendarScreen: React.FC = ({ navigation }: any) => {
   const [isDrawerVisible, setIsDrawerVisible] = useState(false);
@@ -114,9 +115,10 @@ const WorkerMonthlyCalendarScreen: React.FC = ({ navigation }: any) => {
 
   // 월간 요약 계산 (근무 총 시간/급여)
   const monthLabel = `${month + 1}월`;
-  const totalMinutes = works.reduce((sum, w) => sum + w.totalWorkMinutes, 0);
-  const totalHours = Math.round((totalMinutes / 60) * 10) / 10;
-  const estimatedPay = works.reduce((sum, w) => sum + (w.totalSalary ?? 0), 0);
+  const { totalHours, estimatedPay } = useMemo(
+    () => calculateWorkSummary(works),
+    [works]
+  );
 
   return (
     <SafeAreaView style={styles.container}>

--- a/src/screens/worker/WorkerWeeklyCalendarScreen.tsx
+++ b/src/screens/worker/WorkerWeeklyCalendarScreen.tsx
@@ -31,6 +31,7 @@ import {
 	getWeekLabel,
 	getWeekRange,
 } from "../../utils/date";
+import { calculateWorkSummary } from "../../utils/workSummary";
 
 type Props = NativeStackScreenProps<WorkerStackParamList, "WorkerHomeMain">;
 
@@ -128,14 +129,9 @@ const WorkerWeeklyCalendarScreen: React.FC<Props> = ({ navigation }) => {
 	} = useCorrectionRequest();
 
 	// 주간 요약 계산
-	const totalMinutes = works.reduce(
-		(sum, w) => sum + w.totalWorkMinutes,
-		0
-	);
-	const totalHours = Math.round((totalMinutes / 60) * 10) / 10;
-	const estimatedPay = works.reduce(
-		(sum, w) => sum + (w.totalSalary ?? 0),
-		0
+	const { totalHours, estimatedPay } = useMemo(
+		() => calculateWorkSummary(works),
+		[works]
 	);
 
 	return (

--- a/src/utils/workSummary.ts
+++ b/src/utils/workSummary.ts
@@ -1,0 +1,31 @@
+import type { WorkItem } from "../types/worker.types";
+
+export interface WorkSummary {
+	totalHours: number;
+	estimatedPay: number;
+}
+
+/**
+ * 근무 목록에서 요약(총 근무시간, 예상 근무비) 계산.
+ * - 총 근무시간: COMPLETED 근무의 totalWorkMinutes 합산
+ * - 예상 근무비: COMPLETED는 totalSalary, SCHEDULED는 hourlyWage × 시간으로 추정 (DELETED 제외)
+ *   세금/보험은 고려하지 않는 단순 추정치.
+ */
+export const calculateWorkSummary = (works: WorkItem[]): WorkSummary => {
+	let completedMinutes = 0;
+	let estimatedPay = 0;
+
+	for (const work of works) {
+		if (work.status === "COMPLETED") {
+			completedMinutes += work.totalWorkMinutes;
+			estimatedPay += work.totalSalary ?? 0;
+		} else if (work.status === "SCHEDULED") {
+			const hourlyWage = work.hourlyWage ?? 0;
+			estimatedPay += Math.round((hourlyWage * work.totalWorkMinutes) / 60);
+		}
+	}
+
+	const totalHours = Math.round((completedMinutes / 60) * 10) / 10;
+
+	return { totalHours, estimatedPay };
+};

--- a/src/utils/workSummary.ts
+++ b/src/utils/workSummary.ts
@@ -6,23 +6,22 @@ export interface WorkSummary {
 }
 
 /**
- * 근무 목록에서 요약(총 근무시간, 예상 근무비) 계산.
+ * 근무 목록에서 요약(총 근무시간, 예상 근무비) 계산. DELETED 근무는 두 값 모두 제외.
  * - 총 근무시간: COMPLETED 근무의 totalWorkMinutes 합산
- * - 예상 근무비: COMPLETED는 totalSalary, SCHEDULED는 hourlyWage × 시간으로 추정 (DELETED 제외)
- *   세금/보험은 고려하지 않는 단순 추정치.
+ * - 예상 근무비: COMPLETED + SCHEDULED의 totalSalary 합산
+ *   (백엔드가 SCHEDULED도 totalSalary를 계산해 반환 — PayCheck-backend#177)
  */
 export const calculateWorkSummary = (works: WorkItem[]): WorkSummary => {
 	let completedMinutes = 0;
 	let estimatedPay = 0;
 
 	for (const work of works) {
+		if (work.status === "DELETED") continue;
+
 		if (work.status === "COMPLETED") {
 			completedMinutes += work.totalWorkMinutes;
-			estimatedPay += work.totalSalary ?? 0;
-		} else if (work.status === "SCHEDULED") {
-			const hourlyWage = work.hourlyWage ?? 0;
-			estimatedPay += Math.round((hourlyWage * work.totalWorkMinutes) / 60);
 		}
+		estimatedPay += work.totalSalary ?? 0;
 	}
 
 	const totalHours = Math.round((completedMinutes / 60) * 10) / 10;


### PR DESCRIPTION
## 📌 Issue number and Link
closed #55
https://github.com/Team-PayCheck/PayCheck-mobile/issues/55

## ✏️ Summary
근로자 주간/월간 캘린더 상단 요약에서 총 근무시간·예상 근무비 값이 잘못 계산되던 버그 수정.

- **총 근무시간**: 모든 status(SCHEDULED/COMPLETED/DELETED) 시간을 합산하던 것을 → **COMPLETED 근무만 합산**으로 수정
- **예상 근무비**: 완료된 근무 급여만 표시되던 것을 → **COMPLETED + SCHEDULED의 `totalSalary` 합산** (DELETED 제외)으로 수정
  - 백엔드 PR [PayCheck-backend#177](https://github.com/Team-PayCheck/PayCheck-backend/pull/177)에서 SCHEDULED 근무도 `totalSalary`를 계산해 반환하도록 수정됨 (머지 완료) → 프론트에서 `hourlyWage × 시간` 추정 없이 백엔드 계산값을 그대로 사용

## 📝 Changes
- `src/utils/workSummary.ts` (신규): `calculateWorkSummary` 유틸 함수. DELETED 제외, COMPLETED만 시간 합산, COMPLETED+SCHEDULED totalSalary 합산.
- `src/screens/worker/WorkerWeeklyCalendarScreen.tsx`: 인라인 합산 로직 → `calculateWorkSummary` + `useMemo`로 교체
- `src/screens/worker/WorkerMonthlyCalendarScreen.tsx`: 동일한 버그 패턴이 존재하여 함께 수정

## 🔎 PR Type
- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
> ⚠️ **테스트 필요**: 고용주 계정으로는 근로자 캘린더 화면을 확인할 수 없습니다. **근로자 계정 보유 팀원의 테스트가 필요합니다.**
>
> 테스트 시나리오:
> 1. 주간 캘린더 — 이번 주에 COMPLETED + SCHEDULED 근무가 모두 있을 때
>    - 총 근무시간: COMPLETED 시간만 표시되는지
>    - 예상 근무비: COMPLETED 급여 + SCHEDULED 급여(`totalSalary`) 합계가 표시되는지
> 2. DELETED 근무가 있을 때 — 두 값 모두에서 제외되는지
> 3. 근무가 없는 주/월 — `0시간`, `0원` 표시
> 4. 위 시나리오를 월간 캘린더에서도 동일하게 확인