### PR TITLE
[Fix] 근무 요청 카드 시간 박스 겹침 해결 

### DIFF
--- a/src/components/mypage/BaseRequestCard.tsx
+++ b/src/components/mypage/BaseRequestCard.tsx
@@ -165,19 +165,15 @@ const BaseRequestCard: React.FC<BaseRequestCardProps> = ({
 											</View>
 											<View style={styles.detailHourRow}>
 												<View style={styles.detailHourBox}>
-													<Text style={styles.detailValueText}>{parseTime(detail.originalStartTime).hour}</Text>
-												</View>
-												<Text>:</Text>
-												<View style={styles.detailHourBox}>
-													<Text style={styles.detailValueText}>{parseTime(detail.originalStartTime).min}</Text>
+													<Text style={styles.detailValueText}>
+														{parseTime(detail.originalStartTime).hour}:{parseTime(detail.originalStartTime).min}
+													</Text>
 												</View>
 												<Text style={styles.detailTilde}>~</Text>
 												<View style={styles.detailHourBox}>
-													<Text style={styles.detailValueText}>{parseTime(detail.originalEndTime!).hour}</Text>
-												</View>
-												<Text>:</Text>
-												<View style={styles.detailHourBox}>
-													<Text style={styles.detailValueText}>{parseTime(detail.originalEndTime!).min}</Text>
+													<Text style={styles.detailValueText}>
+														{parseTime(detail.originalEndTime!).hour}:{parseTime(detail.originalEndTime!).min}
+													</Text>
 												</View>
 											</View>
 										</View>
@@ -193,19 +189,15 @@ const BaseRequestCard: React.FC<BaseRequestCardProps> = ({
 										</View>
 										<View style={styles.detailHourRow}>
 											<View style={styles.detailHourBox}>
-												<Text style={styles.detailValueText}>{parseTime(detail.requestedStartTime).hour}</Text>
-											</View>
-											<Text>:</Text>
-											<View style={styles.detailHourBox}>
-												<Text style={styles.detailValueText}>{parseTime(detail.requestedStartTime).min}</Text>
+												<Text style={styles.detailValueText}>
+													{parseTime(detail.requestedStartTime).hour}:{parseTime(detail.requestedStartTime).min}
+												</Text>
 											</View>
 											<Text style={styles.detailTilde}>~</Text>
 											<View style={styles.detailHourBox}>
-												<Text style={styles.detailValueText}>{parseTime(detail.requestedEndTime).hour}</Text>
-											</View>
-											<Text>:</Text>
-											<View style={styles.detailHourBox}>
-												<Text style={styles.detailValueText}>{parseTime(detail.requestedEndTime).min}</Text>
+												<Text style={styles.detailValueText}>
+													{parseTime(detail.requestedEndTime).hour}:{parseTime(detail.requestedEndTime).min}
+												</Text>
 											</View>
 										</View>
 									</View>
@@ -380,20 +372,22 @@ const styles = StyleSheet.create({
 		flexDirection: "row",
 		alignItems: "center",
 		justifyContent: "center",
-		gap: 4,
+		gap: 8,
 	},
 	detailHourBox: {
+		flex: 1,
 		backgroundColor: colors.backgroundGrey,
 		borderRadius: 8,
 		paddingVertical: 10,
-		paddingHorizontal: 12,
+		paddingHorizontal: 8,
 		borderWidth: 1,
 		borderColor: colors.borderLight,
-		minWidth: 40,
 		alignItems: "center",
 	},
 	detailTilde: {
-		marginHorizontal: 6,
+		marginHorizontal: 2,
+		color: colors.textPrimary,
+		fontSize: 15,
 	},
 });
 


### PR DESCRIPTION
## 📌 Issue number and Link
closed #60

## ✏️ Summary
보낸/받은 근무 요청 카드의 상세 영역에서 시:분 박스가 좁은 화면(iPhone SE 등)에서 컨테이너를 벗어나 겹쳐 보이던 UI 버그를 해결했습니다.

근본 원인은 한 줄에 8개 element(날짜 박스 + 시 박스 + 분 박스 + ~ + 시 박스 + 분 박스 + 콜론 2개)를 욱여넣은 구조 자체였기 때문에, 단순 크기 축소가 아닌 **시:분을 통합된 "HH:mm" 박스 하나로 단순화**하는 방식으로 해결했습니다.

## 📝 Changes
- `BaseRequestCard.tsx` — 기존/요청 근무 시간 양쪽 모두 시:분 박스 4개 → "HH:mm" 통합 박스 2개로 변경
- `detailHourBox` 스타일에 `flex: 1` 적용 → 화면 너비에 자동 적응 (iPhone SE ~ Pro Max 안정)
- `detailTilde` 스타일에 `color`/`fontSize` 명시로 박스 텍스트와 톤 통일

## 🔎 PR Type
- [x] Bugfix

## 📸 Screenshot
> 팀원 테스트를 위한 PR입니다. 테스트 후 스크린샷 첨부 부탁드립니다.

### 테스트 시나리오
- [ ] **Golden path**: 마이페이지 → 보낸 근무 요청 → 카드 펼침 → 박스 겹침 없이 한 줄 정상 표시
- [ ] **요청 타입 분기**: CREATE / UPDATE / DELETE 각각 정상 표시
- [ ] **회귀 — 받은 요청**: 사장님 계정 → 받은 근무 요청 화면도 정상 표시
- [ ] **회귀 — 카드 헤더**: 접힌 상태의 시간 텍스트(`2/18 09:00 ~ 18:00`)도 그대로 표시
- [ ] **좁은 기기**: iPhone SE급 폭에서 박스 잘림/겹침 없음

### 네이티브 빌드
불필요 (스타일/렌더링 변경만)